### PR TITLE
Enhance 'Tags' description with allowed tags link

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_an_edit.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_an_edit.yml
@@ -22,4 +22,4 @@ body:
   id: tags
   attributes:
     label: "Tags"
-    description: "Suggested tags for the project."
+    description: "Suggested tags for the project. Choose from [allowed tags](https://github.com/JetBrains/klibs-io/blob/master/app/src/main/resources/db/migration/csv_data/2025-10-09-allowed_tags.csv)"


### PR DESCRIPTION
Updated the description for the 'Tags' field to include a link to allowed tags.