### PR TITLE
Added version type field to packages

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
@@ -9,6 +9,7 @@ import io.klibs.app.util.toIndexRequest
 import io.klibs.core.pckg.dto.PackageDTO
 import io.klibs.core.pckg.entity.IndexingRequestEntity
 import io.klibs.core.pckg.enums.IndexingRequestStatus
+import io.klibs.core.pckg.enums.VersionType
 import io.klibs.core.pckg.model.Configuration
 import io.klibs.core.pckg.model.PackageDeveloper
 import io.klibs.core.pckg.model.PackageLicense
@@ -245,6 +246,7 @@ class PackageIndexingService(
             licenses = pom.extractLicenses(),
             configuration = toolingMetadata.toPackageConfiguration(),
             generatedDescription = descriptionWasGenerated,
+            versionType = VersionType.from(pom.version),
             targets = toolingMetadata.projectTargets.map { it.toPackageTarget() }
                 .distinct()
         )

--- a/app/src/main/kotlin/io/klibs/app/job/PackageVersionTypeJob.kt
+++ b/app/src/main/kotlin/io/klibs/app/job/PackageVersionTypeJob.kt
@@ -1,0 +1,28 @@
+package io.klibs.app.job
+
+import io.klibs.core.pckg.service.PackageService
+import net.javacrumbs.shedlock.core.LockAssert
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class PackageVersionTypeJob(private val packageService: PackageService) {
+
+    private val logger = LoggerFactory.getLogger(PackageVersionTypeJob::class.java)
+
+    @Scheduled(initialDelay = 10, fixedDelay = Long.MAX_VALUE, timeUnit = TimeUnit.SECONDS)
+    @SchedulerLock(name = "fillPackageVersionTypeLock", lockAtLeastFor = "365d", lockAtMostFor = "365d")
+    fun fillVersionType() {
+        LockAssert.assertLocked()
+        logger.info("=== Starting one-time job to fill version_type for packages ===")
+
+        val totalUpdated = packageService.fillAllNullVersionTypes()
+
+        logger.info("=== Finished filling version_type for $totalUpdated packages ===")
+    }
+
+}

--- a/app/src/main/resources/db/migration/2026-Q2/2026-04-21_add_version_type_to_package.yml
+++ b/app/src/main/resources/db/migration/2026-Q2/2026-04-21_add_version_type_to_package.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add version_type column to package
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: package
+              columnName: version_type
+      changes:
+        - addColumn:
+            tableName: package
+            columns:
+              - column:
+                  name: version_type
+                  type: VARCHAR(20)

--- a/app/src/main/resources/db/migration/db.changelog-master.yml
+++ b/app/src/main/resources/db/migration/db.changelog-master.yml
@@ -151,4 +151,6 @@ databaseChangeLog:
       file: db/migration/2026-Q2/2026-04-09_package_index_add_kotlin_version.yml
   - include:
       file: db/migration/2026-Q2/2026-04-15_add_2025_grant_winners.yml
+  - include:
+      file: db/migration/2026-Q2/2026-04-21_add_version_type_to_package.yml
 

--- a/build-logic/src/main/kotlin/klibs.spring.gradle.kts
+++ b/build-logic/src/main/kotlin/klibs.spring.gradle.kts
@@ -8,10 +8,9 @@ plugins {
 }
 
 tasks.withType<KotlinCompile> {
-    @Suppress("DEPRECATION")
-    kotlinOptions {
+    compilerOptions {
         // https://kotlinlang.org/docs/java-interop.html#jsr-305-support
-        freeCompilerArgs += "-Xjsr305=strict"
+        freeCompilerArgs.add("-Xjsr305=strict")
     }
 }
 

--- a/core/package/build.gradle.kts
+++ b/core/package/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
     id("klibs.spring-web")
     id("klibs.persistence")
+    id("klibs.mock")
 }
 
 dependencies {
     implementation(projects.integrations.ai)
     implementation(projects.integrations.maven)
+    implementation(libs.kotlin.semver)
 }

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/dto/PackageDTO.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/dto/PackageDTO.kt
@@ -2,6 +2,7 @@ package io.klibs.core.pckg.dto
 
 import io.klibs.core.pckg.entity.PackageEntity
 import io.klibs.core.pckg.entity.PackageTargetEntity
+import io.klibs.core.pckg.enums.VersionType
 import io.klibs.core.pckg.model.Configuration
 import io.klibs.core.pckg.model.PackageDeveloper
 import io.klibs.core.pckg.model.PackageLicense
@@ -31,6 +32,7 @@ data class PackageDTO(
     val licenses: List<PackageLicense>,
     val configuration: Configuration?,
     val generatedDescription: Boolean = false,
+    val versionType: VersionType? = null,
     val targets: List<PackageTarget> = emptyList()
 ) {
     /**
@@ -55,7 +57,8 @@ data class PackageDTO(
             developers = developers,
             licenses = licenses,
             configuration = configuration,
-            generatedDescription = generatedDescription
+            generatedDescription = generatedDescription,
+            versionType = versionType
         )
 
         // Add targets to the entity
@@ -95,6 +98,7 @@ data class PackageDTO(
                 licenses = entity.licenses,
                 configuration = entity.configuration,
                 generatedDescription = entity.generatedDescription,
+                versionType = entity.versionType,
                 targets = entity.targets.map { PackageTarget(it.platform, it.target) }
             )
         }

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/entity/PackageEntity.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/entity/PackageEntity.kt
@@ -1,6 +1,7 @@
 package io.klibs.core.pckg.entity
 
 
+import io.klibs.core.pckg.enums.VersionType
 import io.klibs.core.pckg.model.Configuration
 import io.klibs.core.pckg.model.PackageDeveloper
 import io.klibs.core.pckg.model.PackageLicense
@@ -80,6 +81,10 @@ data class PackageEntity(
 
     @Column(name = "generated_description", nullable = false)
     val generatedDescription: Boolean = false,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "version_type")
+    val versionType: VersionType? = null,
 ) {
     @OneToMany(mappedBy = "packageEntity", cascade = [CascadeType.ALL], orphanRemoval = true)
     val targets: MutableList<PackageTargetEntity> = mutableListOf()
@@ -112,6 +117,7 @@ data class PackageEntity(
      * @param licenses The licenses of the new entity, defaults to the current entity's licenses
      * @param configuration The configuration of the new entity, defaults to the current entity's configuration
      * @param generatedDescription Whether the description was generated, defaults to the current entity's value
+     * @param versionType The version type of the new entity, defaults to the current entity's version type
      * @return A new PackageEntity instance with specified properties changed and targets reattached
      */
     fun deepCopy(
@@ -131,7 +137,8 @@ data class PackageEntity(
         developers: List<PackageDeveloper> = this.developers,
         licenses: List<PackageLicense> = this.licenses,
         configuration: Configuration? = this.configuration,
-        generatedDescription: Boolean = this.generatedDescription
+        generatedDescription: Boolean = this.generatedDescription,
+        versionType: VersionType? = this.versionType
     ): PackageEntity {
         // Create a copy of the entity with specified fields changed
         val copy = PackageEntity(
@@ -151,7 +158,8 @@ data class PackageEntity(
             developers = developers,
             licenses = licenses,
             configuration = configuration,
-            generatedDescription = generatedDescription
+            generatedDescription = generatedDescription,
+            versionType = versionType
         )
 
         // Create new copies of each target and attach them to the new entity

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/enums/VersionType.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/enums/VersionType.kt
@@ -1,0 +1,16 @@
+package io.klibs.core.pckg.enums
+
+import io.github.z4kn4fein.semver.toVersionOrNull
+
+enum class VersionType {
+    STABLE,
+    NON_STABLE,
+    NON_SEMVER;
+
+    companion object {
+        fun from(version: String): VersionType {
+            val semver = version.toVersionOrNull(strict = false) ?: return NON_SEMVER
+            return if (semver.isStable) STABLE else NON_STABLE
+        }
+    }
+}

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/repository/PackageRepository.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/repository/PackageRepository.kt
@@ -4,6 +4,7 @@ import io.klibs.core.pckg.entity.PackageEntity
 import io.klibs.core.pckg.dto.projection.PackageVersionsView
 import io.klibs.core.pckg.model.PackagePlatform
 import io.klibs.core.pckg.dto.projection.SitemapPackageView
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 
@@ -47,6 +48,8 @@ interface PackageRepository: CrudRepository<PackageEntity, Long> {
     fun findDuplicateDescriptions(limit: Int = 1): List<String>
 
     fun findAllByDescription(description: String): List<PackageEntity>
+
+    fun findByVersionTypeIsNull(pageable: Pageable): List<PackageEntity>
 
     fun existsByProjectId(projectId: Int): Boolean
 

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/service/PackageService.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/service/PackageService.kt
@@ -4,6 +4,7 @@ import io.klibs.core.pckg.entity.PackageEntity
 import io.klibs.core.pckg.entity.PackageTargetEntity
 import io.klibs.core.pckg.dto.PackageDTO
 import io.klibs.core.pckg.entity.PackageIndexEntity
+import io.klibs.core.pckg.enums.VersionType
 import io.klibs.core.pckg.model.PackageDetails
 import io.klibs.core.pckg.model.PackageDeveloper
 import io.klibs.core.pckg.model.PackageLicense
@@ -12,15 +13,22 @@ import io.klibs.core.pckg.model.PackageTarget
 import io.klibs.core.pckg.repository.PackageIndexRepository
 import io.klibs.core.pckg.dto.projection.SitemapPackageView
 import io.klibs.core.pckg.repository.PackageRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional(readOnly = true)
 class PackageService(
     private val packageRepository: PackageRepository,
-    private val packageIndexRepository: PackageIndexRepository
+    private val packageIndexRepository: PackageIndexRepository,
+    private val selfProvider: ObjectProvider<PackageService>
 ) {
+    private val logger = LoggerFactory.getLogger(PackageService::class.java)
+
     @Transactional(readOnly = false)
     fun updateByCoordinates(packageDTO: PackageDTO): PackageDTO? {
         val existingPackage = packageRepository.findByGroupIdAndArtifactIdAndVersion(
@@ -72,6 +80,28 @@ class PackageService(
 
     fun findAllPackagesForSitemap(): List<SitemapPackageView> =
         packageRepository.findAllPackagesForSitemap()
+
+    fun fillAllNullVersionTypes(batchSize: Int = 1000): Int {
+        var totalUpdated = 0
+        while (true) {
+            val updated = selfProvider.getObject().fillNullVersionTypes(batchSize)
+            totalUpdated += updated
+            if (updated < batchSize) return totalUpdated
+            logger.info("Updated $totalUpdated packages' version_type so far.")
+        }
+    }
+
+    @Transactional(readOnly = false, propagation = Propagation.REQUIRES_NEW)
+    fun fillNullVersionTypes(batchSize: Int): Int {
+        val batch = packageRepository.findByVersionTypeIsNull(PageRequest.ofSize(batchSize))
+        if (batch.isEmpty()) return 0
+
+        val updated = batch.map { pkg ->
+            pkg.deepCopy(versionType = VersionType.from(pkg.version))
+        }
+        packageRepository.saveAll(updated)
+        return updated.size
+    }
 
     fun getKotlinVersionsByProjectIds(projectIds: List<Int>): Map<Int, String?> {
         if (projectIds.isEmpty()) return emptyMap()

--- a/core/package/src/test/kotlin/io/klibs/core/pckg/enums/VersionTypeTest.kt
+++ b/core/package/src/test/kotlin/io/klibs/core/pckg/enums/VersionTypeTest.kt
@@ -1,0 +1,68 @@
+package io.klibs.core.pckg.enums
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class VersionTypeTest {
+
+    @Test
+    fun `stable release version`() {
+        assertEquals(VersionType.STABLE, VersionType.from("1.0.0"))
+    }
+
+    @Test
+    fun `stable release with higher numbers`() {
+        assertEquals(VersionType.STABLE, VersionType.from("2.3.14"))
+    }
+
+    @Test
+    fun `pre-release alpha version`() {
+        assertEquals(VersionType.NON_STABLE, VersionType.from("1.0.0-alpha"))
+    }
+
+    @Test
+    fun `pre-release beta version`() {
+        assertEquals(VersionType.NON_STABLE, VersionType.from("1.0.0-beta.1"))
+    }
+
+    @Test
+    fun `pre-release rc version`() {
+        assertEquals(VersionType.NON_STABLE, VersionType.from("2.0.0-rc.1"))
+    }
+
+    @Test
+    fun `pre-release snapshot version`() {
+        assertEquals(VersionType.NON_STABLE, VersionType.from("1.0.0-SNAPSHOT"))
+    }
+
+    @Test
+    fun `zero major version is non-stable`() {
+        assertEquals(VersionType.NON_STABLE, VersionType.from("0.1.0"))
+    }
+
+    @Test
+    fun `stable version with build metadata`() {
+        assertEquals(VersionType.STABLE, VersionType.from("1.0.0+build.123"))
+    }
+
+    @Test
+    fun `non-semver version string`() {
+        assertEquals(VersionType.NON_SEMVER, VersionType.from("not-a-version"))
+    }
+
+    @Test
+    fun `non-semver empty string`() {
+        assertEquals(VersionType.NON_SEMVER, VersionType.from(""))
+    }
+
+    @Test
+    fun `loose mode parses single number as non-stable`() {
+        // In loose mode, "1" is parsed as "1.0.0" which is stable
+        assertEquals(VersionType.STABLE, VersionType.from("1"))
+    }
+
+    @Test
+    fun `non-semver date-based version`() {
+        assertEquals(VersionType.NON_SEMVER, VersionType.from("2024.01.15"))
+    }
+}

--- a/core/package/src/test/kotlin/io/klibs/core/pckg/service/PackageServiceTest.kt
+++ b/core/package/src/test/kotlin/io/klibs/core/pckg/service/PackageServiceTest.kt
@@ -1,0 +1,162 @@
+package io.klibs.core.pckg.service
+
+import io.klibs.core.pckg.entity.PackageEntity
+import io.klibs.core.pckg.enums.VersionType
+import io.klibs.core.pckg.repository.PackageIndexRepository
+import io.klibs.core.pckg.repository.PackageRepository
+import io.klibs.integration.maven.ScraperType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import java.time.Instant
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class PackageServiceTest {
+
+    @Mock
+    private lateinit var packageRepository: PackageRepository
+
+    @Mock
+    private lateinit var packageIndexRepository: PackageIndexRepository
+
+    @Mock
+    private lateinit var selfProvider: ObjectProvider<PackageService>
+
+    private lateinit var uut: PackageService
+
+    @BeforeEach
+    fun setUp() {
+        uut = PackageService(
+            packageRepository,
+            packageIndexRepository,
+            selfProvider
+        )
+    }
+
+    @Test
+    fun `fillNullVersionTypes returns 0 when no packages have null version type`() {
+        val pageable = PageRequest.ofSize(100)
+        stubFindByVersionTypeIsNull(pageable, emptyList())
+
+        val result = uut.fillNullVersionTypes(100)
+
+        assertEquals(0, result)
+        verify(packageRepository, never()).saveAll(anyList())
+    }
+
+    @Test
+    fun `fillNullVersionTypes processes a batch and assigns correct version types`() {
+        val pageable = PageRequest.ofSize(100)
+        val stablePackage = createTestPackageEntity(id = 1L, version = "1.0.0")
+        val preReleasePackage = createTestPackageEntity(id = 2L, version = "2.0.0-beta.1")
+        val nonSemverPackage = createTestPackageEntity(id = 3L, version = "not-a-version")
+
+        stubFindByVersionTypeIsNull(pageable, listOf(stablePackage, preReleasePackage, nonSemverPackage))
+        stubSaveAllAndCapture { savedPackages ->
+            assertEquals(3, savedPackages.size)
+            assertEquals(VersionType.STABLE, savedPackages[0].versionType)
+            assertEquals(VersionType.NON_STABLE, savedPackages[1].versionType)
+            assertEquals(VersionType.NON_SEMVER, savedPackages[2].versionType)
+        }
+
+        val result = uut.fillNullVersionTypes(100)
+
+        assertEquals(3, result)
+        verify(packageRepository).saveAll(anyList())
+    }
+
+    @Test
+    fun `fillNullVersionTypes respects batch size parameter`() {
+        val pageable = PageRequest.ofSize(5)
+        val packages = (1L..5L).map { createTestPackageEntity(id = it, version = "$it.0.0") }
+
+        stubFindByVersionTypeIsNull(pageable, packages)
+        stubSaveAllAndCapture { savedPackages ->
+            assertEquals(5, savedPackages.size)
+        }
+
+        val result = uut.fillNullVersionTypes(5)
+
+        assertEquals(5, result)
+        verify(packageRepository).findByVersionTypeIsNull(pageable)
+    }
+
+    @Test
+    fun `fillAllNullVersionTypes processes single batch then stops`() {
+        val pageable = PageRequest.ofSize(100)
+        val packages = listOf(createTestPackageEntity(id = 1L, version = "1.0.0"))
+
+        whenever(selfProvider.getObject()).thenReturn(uut)
+        whenever(packageRepository.findByVersionTypeIsNull(pageable))
+            .thenReturn(packages)
+            .thenReturn(emptyList())
+        stubSaveAllAndCapture { }
+
+        val result = uut.fillAllNullVersionTypes(100)
+
+        assertEquals(1, result)
+        verify(packageRepository, times(1)).findByVersionTypeIsNull(pageable)
+    }
+
+    @Test
+    fun `fillAllNullVersionTypes uses default batch size`() {
+        val pageable = PageRequest.ofSize(1000)
+        whenever(selfProvider.getObject()).thenReturn(uut)
+        stubFindByVersionTypeIsNull(pageable, emptyList())
+
+        uut.fillAllNullVersionTypes()
+
+        verify(packageRepository).findByVersionTypeIsNull(pageable)
+    }
+
+    private fun createTestPackageEntity(
+        id: Long = 1L,
+        version: String = "1.0.0",
+        versionType: VersionType? = null
+    ): PackageEntity {
+        return PackageEntity(
+            id = id,
+            projectId = 100,
+            repo = ScraperType.CENTRAL_SONATYPE,
+            groupId = "io.klibs",
+            artifactId = "test-package",
+            version = version,
+            releaseTs = Instant.now(),
+            description = "A test package",
+            url = "https://example.com",
+            scmUrl = "https://github.com/example/test",
+            buildTool = "gradle",
+            buildToolVersion = "7.0.0",
+            kotlinVersion = "1.5.0",
+            developers = emptyList(),
+            licenses = emptyList(),
+            configuration = null,
+            generatedDescription = false,
+            versionType = versionType
+        )
+    }
+
+    private fun stubFindByVersionTypeIsNull(pageable: Pageable, result: List<PackageEntity>) {
+        whenever(packageRepository.findByVersionTypeIsNull(pageable)).thenReturn(result)
+    }
+
+    /**
+     * Stubs saveAll to capture the saved entities and return them, then runs [verification] on the captured list.
+     */
+    private fun stubSaveAllAndCapture(verification: (List<PackageEntity>) -> Unit) {
+        whenever(packageRepository.saveAll(anyList())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val saved = invocation.arguments[0] as List<PackageEntity>
+            verification(saved)
+            saved
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "2.1.0"
+kotlin = "2.3.20"
 
 # Spring
 spring-boot = "3.5.9"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,8 @@ markdown = "0.7.3"
 
 xml-util = "0.90.0"
 
+kotlin-semver = "3.0.0"
+
 [plugins]
 
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -103,6 +105,8 @@ prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
 
 xml-util = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "xml-util" }
+
+kotlin-semver = { module = "io.github.z4kn4fein:semver", version.ref = "kotlin-semver" }
 
 [bundles]
 maven-indexer = [


### PR DESCRIPTION
Version type is required to differentiate between stable and non-stable versions. Also, we can understand which packages don't use semver at all.

It is first step in a chain of PRs for MCP