### PR TITLE
KTL-4370: Fallback to direct Maven Central upstream if 404

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/job/ProcessPackageIndexRequestJob.kt
+++ b/app/src/main/kotlin/io/klibs/app/job/ProcessPackageIndexRequestJob.kt
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
 @Component
+@ConditionalOnProperty(
+    value = ["klibs.scheduling.process-queue-job.enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
 class ProcessPackageIndexRequestJob(val packageIndexingService: PackageIndexingService) {
 
     @Scheduled(initialDelay = 0, fixedRate = 4, timeUnit = TimeUnit.HOURS)

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -67,6 +67,7 @@ klibs:
         index-endpoint: ${KLIBS_MAVEN_INDEX_ENDPOINT:https://repo1.maven.org/maven2}
         index-dir: ${KLIBS_MAVEN_INDEX_CACHE_DIR:${user.dir}/cache/maven-index}
         content-endpoint: ${KLIBS_MAVEN_CONTENT_ENDPOINT:https://cache-redirector.jetbrains.com/repo1.maven.org/maven2/}
+        content-fallback-endpoint: ${KLIBS_MAVEN_CONTENT_FALLBACK_ENDPOINT:https://search.maven.org/remotecontent?filepath=}
     github:
       personal-access-token: ${KLIBS_GITHUB_TOKEN}
       cache:

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -1,6 +1,9 @@
 klibs:
   indexing: false
   ai: false
+  scheduling:
+    process-queue-job:
+      enabled: false
 
 spring:
   sql:

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/MavenCentralProperties.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/MavenCentralProperties.kt
@@ -14,5 +14,6 @@ data class MavenIntegrationProperties(
         val indexEndpoint: String,
         val indexDir: String,
         val contentEndpoint: String,
+        val contentFallbackEndpoint: String,
     )
 }

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClient.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClient.kt
@@ -116,6 +116,15 @@ abstract class BaseMavenSearchClient(
 
     protected abstract fun getContentUrlPrefix(): String
 
+    /**
+     * URL prefix to retry content fetches against when [getContentUrlPrefix] returns 404. Returning `null`
+     * (the default) disables the fallback.
+     *
+     * Used to bypass intermediaries (e.g. cache-redirector) that may return spurious 404s for newly published
+     * artifacts that exist on the upstream origin.
+     */
+    protected open fun getContentFallbackUrlPrefix(): String? = null
+
     protected fun <T> executeWithThrottle(body: () -> T): T {
         try {
             return rateLimiter.withRateLimitBlocking {
@@ -132,8 +141,23 @@ abstract class BaseMavenSearchClient(
         headers: Map<String, String> = emptyMap(),
         converter: (response: Transport.Response) -> R,
     ): R? {
-        return followRedirects(
+        val primary = followRedirects(
             serviceUri = serviceUri,
+            headers = headers,
+            converter = converter,
+            redirectCount = 0,
+            requestExecutor = clientTransport::get
+        )
+        if (primary != null) return primary
+
+        val primaryPrefix = getContentUrlPrefix()
+        val fallbackPrefix = getContentFallbackUrlPrefix() ?: return null
+        if (fallbackPrefix == primaryPrefix || !serviceUri.startsWith(primaryPrefix)) return null
+
+        val fallbackUri = fallbackPrefix + serviceUri.removePrefix(primaryPrefix)
+        logger.warn("Primary content endpoint returned 404 for {}, retrying via {}", serviceUri, fallbackUri)
+        return followRedirects(
+            serviceUri = fallbackUri,
             headers = headers,
             converter = converter,
             redirectCount = 0,

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/CentralSonatypeSearchClient.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/CentralSonatypeSearchClient.kt
@@ -27,6 +27,8 @@ class CentralSonatypeSearchClient(
     objectMapper: ObjectMapper,
     @Value("\${klibs.integration.maven.central.content-endpoint}")
     private val contentEndpoint: String,
+    @Value("\${klibs.integration.maven.central.content-fallback-endpoint}")
+    private val contentFallbackEndpoint: String,
 ) : BaseMavenSearchClient(
     xmlMapper,
     mavenCentralRateLimiter,
@@ -60,6 +62,10 @@ class CentralSonatypeSearchClient(
 
     override fun getContentUrlPrefix(): String {
         return contentEndpoint
+    }
+
+    override fun getContentFallbackUrlPrefix(): String {
+        return contentFallbackEndpoint
     }
 
     private fun Record.toArtifactData(): ArtifactData {

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/MavenMetricsTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/MavenMetricsTest.kt
@@ -19,7 +19,8 @@ class MavenMetricsTest {
                 discoveryEndpoint = "http://localhost/discovery",
                 indexEndpoint = "http://localhost/index",
                 indexDir = "/tmp/maven-index",
-                contentEndpoint = "http://localhost/content/"
+                contentEndpoint = "http://localhost/content/",
+                contentFallbackEndpoint = "http://localhost/fallback/"
             )
         )
         

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClientRedirectTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClientRedirectTest.kt
@@ -129,6 +129,36 @@ class BaseMavenSearchClientRedirectTest {
         assertNull(result, "Expected null for HTTP 404 response")
     }
 
+    @Test
+    fun `pom 404 on primary falls back to upstream and returns the pom`() {
+        val pom = minimalPom("org.example", "example-artifact", "1.0.0")
+        val primary404 = mockResponse(code = 404)
+        val upstreamOk = mockResponse(code = 200, body = pom)
+        whenever(transport.get(any(), any())).thenReturn(primary404, upstreamOk)
+
+        val fallbackClient = TestClient(transport, fallbackPrefix = "https://upstream/maven2/")
+        val result = fallbackClient.getPom(
+            MavenArtifact("org.example", "example-artifact", "1.0.0", ScraperType.CENTRAL_SONATYPE)
+        )
+
+        assertNotNull(result, "Expected POM via fallback after primary 404")
+        assertEquals("example-artifact", result.artifactId)
+    }
+
+    @Test
+    fun `pom 404 on both primary and fallback returns null`() {
+        val primary404 = mockResponse(code = 404)
+        val fallback404 = mockResponse(code = 404)
+        whenever(transport.get(any(), any())).thenReturn(primary404, fallback404)
+
+        val fallbackClient = TestClient(transport, fallbackPrefix = "https://upstream/maven2/")
+        val result = fallbackClient.getPom(
+            MavenArtifact("org.example", "example-artifact", "1.0.0", ScraperType.CENTRAL_SONATYPE)
+        )
+
+        assertNull(result, "Expected null when fallback also returns 404")
+    }
+
     private fun minimalPom(groupId: String, artifactId: String, version: String): String = """
         |<?xml version="1.0" encoding="UTF-8"?>
         |<project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -161,7 +191,10 @@ class BaseMavenSearchClientRedirectTest {
         return response
     }
 
-    private class TestClient(transport: Transport) : BaseMavenSearchClient(
+    private class TestClient(
+        transport: Transport,
+        private val fallbackPrefix: String? = null,
+    ) : BaseMavenSearchClient(
         xmlMapper = XmlMapper().apply { registerKotlinModule() },
         rateLimiter = UnlimitedRateLimiter(),
         logger = LoggerFactory.getLogger(TestClient::class.java),
@@ -171,6 +204,8 @@ class BaseMavenSearchClientRedirectTest {
         override fun getContentUrlPrefix(): String {
             return "https://test/remotecontent?filepath="
         }
+
+        override fun getContentFallbackUrlPrefix(): String? = fallbackPrefix
 
         override fun searchWithThrottle(
             page: Int,

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/service/MavenIndexScannerServiceTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/service/MavenIndexScannerServiceTest.kt
@@ -51,7 +51,8 @@ class MavenIndexScannerServiceTest {
                 discoveryEndpoint = "http://localhost",
                 indexEndpoint = "http://localhost",
                 indexDir = "build/tmp/maven-index",
-                contentEndpoint = "http://localhost/content/"
+                contentEndpoint = "http://localhost/content/",
+                contentFallbackEndpoint = "http://localhost/fallback/"
             )
         )
         indexingContextManager = MavenIndexingContextManager(properties, indexer, emptyList())

--- a/integrations/maven/src/test/resources/application-test.yml
+++ b/integrations/maven/src/test/resources/application-test.yml
@@ -16,3 +16,4 @@ klibs:
         indexEndpoint: http://localhost:8080/index
         indexDir: /tmp/maven-index
         content-endpoint: http://localhost:8080/content/
+        content-fallback-endpoint: http://localhost:8080/fallback/


### PR DESCRIPTION
Previously, we introduced using cache redirector to decrease maven central requests quota usage.
However, turns out that on cache miss somewhere in the redirector chain (cache-redirector → cloudfront → origin-pull) we get 404, often for new artifacts.
Fallbacking to origin fixes the problem.