### PR TITLE
WIP: spec driven workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,27 @@
+---
+description: Implement one milestone from an approved klibs.io plan; stops after the milestone per CLAUDE.md.
+---
+
+# /implement
+
+Implement exactly one milestone from an approved plan. This command enforces CLAUDE.md's "Execute step" rule: one milestone, then STOP.
+
+## Input
+$ARGUMENTS
+
+`$ARGUMENTS` should identify the milestone (e.g. `1`, `2`, or `next`). If empty or `next`, find the first milestone in the plan that hasn't been implemented yet (use git log and file state to determine).
+
+## Process
+1. **Read the plan** under the most recently modified `docs/specs/*/plan.md`. Confirm the milestone exists and resolve `next` if used.
+2. **Read the spec** in the same directory for context.
+3. **Implement only the chosen milestone.** Constraints:
+    - Touch only the files listed for that milestone, plus tests for those files. If you must touch additional files, STOP first and explain why.
+    - Match existing patterns (JPA vs JDBC, annotation style, test base class) — grep before inventing.
+    - Run the milestone's validation command before declaring done.
+4. **STOP after the milestone.** Do not start the next milestone, even if it looks small. Report:
+    - Per-file change summary (one line each)
+    - Validation: command run + result
+    - Risks / follow-ups
+    - Any deviation from the plan, and why
+
+Do not commit or push. The human reviews and commits.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,30 @@
+---
+description: Generate an implementation plan from an existing klibs.io spec; produces 2–4 milestones for review.
+---
+
+# /plan
+
+Generate an implementation plan from the spec referenced below. The plan must follow `.claude/templates/plan.md` and respect CLAUDE.md's "Align → Execute" milestone gating.
+
+## Input
+$ARGUMENTS
+
+If `$ARGUMENTS` is empty or doesn't reference a spec file, auto-discover the most recently modified file matching `docs/specs/*/spec.md` and use that.
+
+## Process
+1. **Read the spec.** Do not generate a plan if the spec still contains unresolved `[NEEDS CLARIFICATION]` markers — instead, list them and ask the human to resolve them in the spec first.
+2. **Determine the slug** from the spec's directory name.
+3. **Read `.claude/templates/plan.md`** for structure.
+4. **Propose 2–4 milestones.** Constraints:
+    - Each milestone is independently mergeable and testable.
+    - Each milestone touches the minimum files needed.
+    - Validation must be a runnable command or a concrete observation — not "manually verify it works".
+    - If a milestone needs more than 4 lines of description, split it.
+5. **Respect klibs.io module-by-feature boundaries.** A single milestone may touch multiple modules only if they're logically inseparable (e.g., a migration changeset + the JPA entity that maps it).
+6. **Write the result to `docs/specs/<slug>/plan.md`.**
+7. **STOP.** Report:
+    - Path of the file written
+    - Any spec ambiguity that forced a planning assumption
+    - Any milestone you considered splitting further but chose not to, and why
+
+Do not implement anything. The plan is the deliverable.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -13,7 +13,7 @@ If `$ARGUMENTS` is empty or doesn't reference a spec file, auto-discover the mos
 
 ## Process
 1. **Read the spec.** Do not generate a plan if the spec still contains unresolved `[NEEDS CLARIFICATION]` markers — instead, list them and ask the human to resolve them in the spec first.
-2. **Determine the slug** from the spec's directory name.
+2. **The feature name is the spec's directory name** (under `docs/specs/`).
 3. **Read `.claude/templates/plan.md`** for structure.
 4. **Propose 2–4 milestones.** Constraints:
     - Each milestone is independently mergeable and testable.
@@ -21,7 +21,7 @@ If `$ARGUMENTS` is empty or doesn't reference a spec file, auto-discover the mos
     - Validation must be a runnable command or a concrete observation — not "manually verify it works".
     - If a milestone needs more than 4 lines of description, split it.
 5. **Respect klibs.io module-by-feature boundaries.** A single milestone may touch multiple modules only if they're logically inseparable (e.g., a migration changeset + the JPA entity that maps it).
-6. **Write the result to `docs/specs/<slug>/plan.md`.**
+6. **Write the result to `docs/specs/<feature-name>/plan.md`.**
 7. **STOP.** Report:
     - Path of the file written
     - Any spec ambiguity that forced a planning assumption

--- a/.claude/commands/spec-from-spike.md
+++ b/.claude/commands/spec-from-spike.md
@@ -1,0 +1,37 @@
+---
+description: Formalize a completed klibs.io spike into a feature spec — treat the spike's findings (not its code) as the source of truth.
+---
+
+# /spec-from-spike
+
+Formalize what a completed spike *taught* into a real spec ready for human review. The spike code is **not** the source of truth — the *learnings* are. Do not transcribe spike implementation choices into functional requirements; question them.
+
+The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors).
+
+If you're starting fresh from a vague task description (no spike), use `/specify` instead.
+
+## Input
+$ARGUMENTS
+
+`$ARGUMENTS` should be the spike's name (the directory name under `docs/spikes/`). If empty, ask which spike to formalize.
+
+## Process
+1. **Read `docs/spikes/<spike-name>/findings.md`** to understand the goal, verdict, and implications.
+2. **Read the files listed under "Files touched"** in findings.md to see what the spike actually did — as secondary evidence only.
+3. **Pick a fresh name for the production spec** — often different from the spike's name, since the spec is a deliberate redesign. Lowercase with hyphens, e.g. `oss-health-metric`.
+4. **Read `.claude/templates/spec.md`** for the full structure.
+5. **Fill in every applicable section**, with these extra rules:
+    - Cite the spike in §12 References: `Spike: docs/spikes/<spike-name>/findings.md`.
+    - In §8 Design options, capture what the spike ruled out (Option A = the approach the spike tried but found problematic; Decision = the refined approach). If the spike's approach was obviously right, skip §8.
+    - In §11 Assumptions, include any constraint the spike discovered (rate-limit ceilings, schema gotchas, surprise API behaviors).
+    - Spike code does not match production patterns (JPA vs JDBC, error handling, etc.). §7 must explicitly state which production patterns the real implementation will follow — don't inherit the spike's choices by default.
+    - For anything you can't answer from the spike's findings, insert `[NEEDS CLARIFICATION: <specific question>]` inline. Do not invent details to fill silence.
+    - Don't include why-now / priority-rationale / project-management context.
+6. **Write to `docs/specs/<feature-name>/spec.md`** — never overwrite the spike. Both artifacts stay.
+7. **STOP.** Do not generate a plan, tasks, or code. Report back:
+    - Path of the spec written
+    - Which spike findings shaped which spec sections
+    - Anything the spike *did* that you're deliberately *not* carrying into the spec, and why
+    - `[NEEDS CLARIFICATION]` markers and top-3 assumptions
+
+The spec is the deliverable. Plan and implementation come later under separate commands.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,0 +1,25 @@
+---
+description: Generate a klibs.io feature spec from a vague task description, ready for human review.
+---
+
+# /specify
+
+Generate a feature specification from the user's input below. The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors, etc.).
+
+## Input
+$ARGUMENTS
+
+## Process
+1. **Pick a short kebab-case slug** for the feature (3–6 words). Derive from the main noun phrase of the input if not obvious.
+2. **Read `.claude/templates/spec.md`** for the full structure.
+3. **Fill in every applicable section.** The template marks several sections "include only what applies" / "mark only lines that apply" — omit lines and entire sections that don't apply rather than leaving empty placeholders. A small spec may legitimately use only sections 1–4 and 7.
+4. **For anything you can't answer from the input**, insert `[NEEDS CLARIFICATION: <specific question>]` inline at the point it matters. Do not invent details to fill silence.
+5. **Don't include why-now / priority-rationale / project-management context.** Those are settled by the time the spec exists. Capture only consequences that shape implementation.
+6. **Write the result to `docs/specs/<slug>/spec.md`.** Create the directory if needed.
+7. **STOP.** Do not generate a plan, tasks, or code. Report back:
+    - Path of the file written
+    - List of every `[NEEDS CLARIFICATION]` marker you inserted, with the line it sits on
+    - Up to 3 assumptions you'd most like the reviewer to confirm or correct
+    - Any sections you deliberately omitted, and why
+
+The spec is the deliverable for this command. Plan and implementation come later under separate commands.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,15 +1,23 @@
 ---
-description: Generate a klibs.io feature spec from a vague task description, ready for human review.
+description: Generate a klibs.io feature spec — from a vague task description, or from a completed spike (`--from-spike <slug>`).
 ---
 
 # /specify
 
-Generate a feature specification from the user's input below. The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors, etc.).
+Generate a feature specification ready for human review. The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors, etc.).
 
 ## Input
 $ARGUMENTS
 
-## Process
+## Mode detection
+
+Inspect `$ARGUMENTS`:
+
+- If it begins with `--from-spike <slug>`, operate in **reverse-spec mode** (see below).
+- Otherwise, operate in **forward-spec mode** (default).
+
+## Forward-spec mode (default)
+
 1. **Pick a short kebab-case slug** for the feature (3–6 words). Derive from the main noun phrase of the input if not obvious.
 2. **Read `.claude/templates/spec.md`** for the full structure.
 3. **Fill in every applicable section.** The template marks several sections "include only what applies" / "mark only lines that apply" — omit lines and entire sections that don't apply rather than leaving empty placeholders. A small spec may legitimately use only sections 1–4 and 7.
@@ -22,4 +30,23 @@ $ARGUMENTS
     - Up to 3 assumptions you'd most like the reviewer to confirm or correct
     - Any sections you deliberately omitted, and why
 
-The spec is the deliverable for this command. Plan and implementation come later under separate commands.
+## Reverse-spec mode (`--from-spike <slug>`)
+
+You're formalizing what a completed spike *taught* into a real spec. The spike code is **not** the source of truth — the *learnings* are. Do not transcribe spike implementation choices into FRs; question them.
+
+1. **Read `docs/spikes/<slug>/findings.md`** to understand the question, verdict, and implications.
+2. **Read the files listed under "Files touched"** in findings.md to see what the spike actually did.
+3. **Derive a fresh spec slug** for the production work — often different from the spike slug, since the spec is a deliberate redesign.
+4. **Fill in `.claude/templates/spec.md` as in forward-spec mode**, with these extra rules:
+    - Cite the spike in §12 References: `Spike: docs/spikes/<spike-slug>/findings.md`.
+    - In §8 Design options, capture what the spike ruled out (Option A = the approach the spike tried but found problematic; Decision = the refined approach). If the spike's approach was obviously right, skip §8.
+    - In §11 Assumptions, include any constraint the spike discovered (rate-limit ceilings, schema gotchas, surprise API behaviors).
+    - Spike code does not match production patterns (JPA vs JDBC, error handling, etc.). §7 must explicitly state which production patterns the real implementation will follow — don't inherit the spike's choices by default.
+5. **Write to `docs/specs/<new-slug>/spec.md`** — never overwrite the spike. Both artifacts stay.
+6. **STOP.** Report:
+    - Path of the spec written
+    - Which spike findings shaped which spec sections
+    - Anything the spike *did* that you're deliberately *not* carrying into the spec, and why
+    - `[NEEDS CLARIFICATION]` markers and top-3 assumptions
+
+The spec is the deliverable. Plan and implementation come later under separate commands.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,23 +1,15 @@
 ---
-description: Generate a klibs.io feature spec — from a vague task description, or from a completed spike (`--from-spike <spike-name>`).
+description: Generate a klibs.io feature spec from a vague task description, ready for human review.
 ---
 
 # /specify
 
-Generate a feature specification ready for human review. The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors, etc.).
+Generate a feature specification from the user's input below. The spec must follow the template at `.claude/templates/spec.md` and respect the rules in `CLAUDE.md` (module-by-feature boundaries, minimal diff, no unsolicited refactors, etc.).
 
 ## Input
 $ARGUMENTS
 
-## Mode detection
-
-Inspect `$ARGUMENTS`:
-
-- If it begins with `--from-spike <spike-name>`, operate in **reverse-spec mode** (see below).
-- Otherwise, operate in **forward-spec mode** (default).
-
-## Forward-spec mode (default)
-
+## Process
 1. **Pick a short name for the feature** — 3–6 words, lowercase with hyphens (e.g. `oss-health-metric`). This becomes the directory under `docs/specs/`. Derive it from the main noun phrase of the input if not obvious.
 2. **Read `.claude/templates/spec.md`** for the full structure.
 3. **Fill in every applicable section.** The template marks several sections "include only what applies" / "mark only lines that apply" — omit lines and entire sections that don't apply rather than leaving empty placeholders. A small spec may legitimately use only sections 1–4 and 7.
@@ -30,23 +22,4 @@ Inspect `$ARGUMENTS`:
     - Up to 3 assumptions you'd most like the reviewer to confirm or correct
     - Any sections you deliberately omitted, and why
 
-## Reverse-spec mode (`--from-spike <spike-name>`)
-
-You're formalizing what a completed spike *taught* into a real spec. The spike code is **not** the source of truth — the *learnings* are. Do not transcribe spike implementation choices into FRs; question them.
-
-1. **Read `docs/spikes/<spike-name>/findings.md`** to understand the question, verdict, and implications.
-2. **Read the files listed under "Files touched"** in findings.md to see what the spike actually did.
-3. **Pick a fresh name for the production spec** — often different from the spike's name, since the spec is a deliberate redesign.
-4. **Fill in `.claude/templates/spec.md` as in forward-spec mode**, with these extra rules:
-    - Cite the spike in §12 References: `Spike: docs/spikes/<spike-name>/findings.md`.
-    - In §8 Design options, capture what the spike ruled out (Option A = the approach the spike tried but found problematic; Decision = the refined approach). If the spike's approach was obviously right, skip §8.
-    - In §11 Assumptions, include any constraint the spike discovered (rate-limit ceilings, schema gotchas, surprise API behaviors).
-    - Spike code does not match production patterns (JPA vs JDBC, error handling, etc.). §7 must explicitly state which production patterns the real implementation will follow — don't inherit the spike's choices by default.
-5. **Write to `docs/specs/<feature-name>/spec.md`** — never overwrite the spike. Both artifacts stay.
-6. **STOP.** Report:
-    - Path of the spec written
-    - Which spike findings shaped which spec sections
-    - Anything the spike *did* that you're deliberately *not* carrying into the spec, and why
-    - `[NEEDS CLARIFICATION]` markers and top-3 assumptions
-
-The spec is the deliverable. Plan and implementation come later under separate commands.
+The spec is the deliverable for this command. Plan and implementation come later under separate commands.

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a klibs.io feature spec — from a vague task description, or from a completed spike (`--from-spike <slug>`).
+description: Generate a klibs.io feature spec — from a vague task description, or from a completed spike (`--from-spike <spike-name>`).
 ---
 
 # /specify
@@ -13,36 +13,36 @@ $ARGUMENTS
 
 Inspect `$ARGUMENTS`:
 
-- If it begins with `--from-spike <slug>`, operate in **reverse-spec mode** (see below).
+- If it begins with `--from-spike <spike-name>`, operate in **reverse-spec mode** (see below).
 - Otherwise, operate in **forward-spec mode** (default).
 
 ## Forward-spec mode (default)
 
-1. **Pick a short kebab-case slug** for the feature (3–6 words). Derive from the main noun phrase of the input if not obvious.
+1. **Pick a short name for the feature** — 3–6 words, lowercase with hyphens (e.g. `oss-health-metric`). This becomes the directory under `docs/specs/`. Derive it from the main noun phrase of the input if not obvious.
 2. **Read `.claude/templates/spec.md`** for the full structure.
 3. **Fill in every applicable section.** The template marks several sections "include only what applies" / "mark only lines that apply" — omit lines and entire sections that don't apply rather than leaving empty placeholders. A small spec may legitimately use only sections 1–4 and 7.
 4. **For anything you can't answer from the input**, insert `[NEEDS CLARIFICATION: <specific question>]` inline at the point it matters. Do not invent details to fill silence.
 5. **Don't include why-now / priority-rationale / project-management context.** Those are settled by the time the spec exists. Capture only consequences that shape implementation.
-6. **Write the result to `docs/specs/<slug>/spec.md`.** Create the directory if needed.
+6. **Write the result to `docs/specs/<feature-name>/spec.md`.** Create the directory if needed.
 7. **STOP.** Do not generate a plan, tasks, or code. Report back:
     - Path of the file written
     - List of every `[NEEDS CLARIFICATION]` marker you inserted, with the line it sits on
     - Up to 3 assumptions you'd most like the reviewer to confirm or correct
     - Any sections you deliberately omitted, and why
 
-## Reverse-spec mode (`--from-spike <slug>`)
+## Reverse-spec mode (`--from-spike <spike-name>`)
 
 You're formalizing what a completed spike *taught* into a real spec. The spike code is **not** the source of truth — the *learnings* are. Do not transcribe spike implementation choices into FRs; question them.
 
-1. **Read `docs/spikes/<slug>/findings.md`** to understand the question, verdict, and implications.
+1. **Read `docs/spikes/<spike-name>/findings.md`** to understand the question, verdict, and implications.
 2. **Read the files listed under "Files touched"** in findings.md to see what the spike actually did.
-3. **Derive a fresh spec slug** for the production work — often different from the spike slug, since the spec is a deliberate redesign.
+3. **Pick a fresh name for the production spec** — often different from the spike's name, since the spec is a deliberate redesign.
 4. **Fill in `.claude/templates/spec.md` as in forward-spec mode**, with these extra rules:
-    - Cite the spike in §12 References: `Spike: docs/spikes/<spike-slug>/findings.md`.
+    - Cite the spike in §12 References: `Spike: docs/spikes/<spike-name>/findings.md`.
     - In §8 Design options, capture what the spike ruled out (Option A = the approach the spike tried but found problematic; Decision = the refined approach). If the spike's approach was obviously right, skip §8.
     - In §11 Assumptions, include any constraint the spike discovered (rate-limit ceilings, schema gotchas, surprise API behaviors).
     - Spike code does not match production patterns (JPA vs JDBC, error handling, etc.). §7 must explicitly state which production patterns the real implementation will follow — don't inherit the spike's choices by default.
-5. **Write to `docs/specs/<new-slug>/spec.md`** — never overwrite the spike. Both artifacts stay.
+5. **Write to `docs/specs/<feature-name>/spec.md`** — never overwrite the spike. Both artifacts stay.
 6. **STOP.** Report:
     - Path of the spec written
     - Which spike findings shaped which spec sections

--- a/.claude/commands/specify.md
+++ b/.claude/commands/specify.md
@@ -13,12 +13,15 @@ $ARGUMENTS
 1. **Pick a short name for the feature** — 3–6 words, lowercase with hyphens (e.g. `oss-health-metric`). This becomes the directory under `docs/specs/`. Derive it from the main noun phrase of the input if not obvious.
 2. **Read `.claude/templates/spec.md`** for the full structure.
 3. **Fill in every applicable section.** The template marks several sections "include only what applies" / "mark only lines that apply" — omit lines and entire sections that don't apply rather than leaving empty placeholders. A small spec may legitimately use only sections 1–4 and 7.
-4. **For anything you can't answer from the input**, insert `[NEEDS CLARIFICATION: <specific question>]` inline at the point it matters. Do not invent details to fill silence.
-5. **Don't include why-now / priority-rationale / project-management context.** Those are settled by the time the spec exists. Capture only consequences that shape implementation.
-6. **Write the result to `docs/specs/<feature-name>/spec.md`.** Create the directory if needed.
-7. **STOP.** Do not generate a plan, tasks, or code. Report back:
+4. **Separate requirements from design decisions — the most common failure.** §4 is observable contracts only; every "how / which mechanism" choice goes to §8. After drafting §4, **re-scan it against the template's §4 litmus** and move anything misfiled to §8.
+5. **For anything you can't answer from the input**, insert `[NEEDS CLARIFICATION: <specific question>]` inline at the point it matters. Do not invent details to fill silence.
+6. **Make sure that the spec does not contain memory links: it should contain resolved facts.**
+7. **Don't include why-now / priority-rationale / project-management context.** Those are settled by the time the spec exists. Capture only consequences that shape implementation.
+8. **Write the result to `docs/specs/<feature-name>/spec.md`.** Create the directory if needed.
+9. **STOP.** Do not generate a plan, tasks, or code. Report back:
     - Path of the file written
     - List of every `[NEEDS CLARIFICATION]` marker you inserted, with the line it sits on
+    - The design decisions you recorded in §8 — so the reviewer can challenge the *how* separately from the *what*
     - Up to 3 assumptions you'd most like the reviewer to confirm or correct
     - Any sections you deliberately omitted, and why
 

--- a/.claude/commands/spike.md
+++ b/.claude/commands/spike.md
@@ -4,31 +4,32 @@ description: Throwaway exploratory prototype to validate an idea — no spec, no
 
 # /spike
 
-Run a throwaway exploration to answer a specific question or test a hypothesis. This command intentionally **suppresses** CLAUDE.md's Align → Execute milestone gating — that gate exists to keep production work disciplined, and it would defeat the purpose of a spike.
+Run a throwaway exploration — to answer a specific question, test a hypothesis, or build a rough end-to-end version of something and see where it breaks. This command intentionally **suppresses** CLAUDE.md's Align → Execute milestone gating — that gate exists to keep production work disciplined, and it would defeat the purpose of a spike.
 
-A spike is not production code. Its only deliverable is **learning**, captured in a findings document.
+A spike is not production code. Its only deliverable is **learning**, captured in a findings document. The spike code itself may survive (as inspiration for the eventual real implementation) or be thrown away.
 
 ## Input
 $ARGUMENTS
 
-A specific question or hypothesis. Examples:
+A specific question, hypothesis, or build target. Examples (small to large):
 - "Can we extract dependents count from Maven Central without exceeding the solrsearch rate limit?"
 - "Does the OssHealth score still make sense if we drop the issue-velocity component?"
 - "Try PostgreSQL FTS `rank_cd` vs `ts_rank` — which gives better results for our queries?"
+- "Build a rough end-to-end implementation of the OSS health metric per <design doc link> — find out where the design breaks down before we formalize."
 
-If `$ARGUMENTS` is vague (e.g. "spike a thing"), STOP and ask for a specific question.
+If `$ARGUMENTS` is vague (e.g. "spike a thing"), STOP and ask for a specific question or build target.
 
 ## Process
-1. **Pick a short kebab-case slug** for the spike (3–6 words).
-2. **Time-box.** A spike is small. If you find yourself touching more than ~5 files, STOP and reconsider — this should probably be a real spec.
+1. **Pick a short name for the spike** — 3–6 words, lowercase with hyphens (e.g. `solrsearch-rate-limit-probe`). This becomes the directory under `docs/spikes/`.
+2. **Stay in spike discipline, not spike size.** A spike can be tiny (one file probing one question) or large (a vibecoded end-to-end prototype touching many files). What makes it a spike is *throwaway intent* and *skipped production discipline* — not file count. If you find yourself wanting to add tests, match JPA/JDBC patterns, or polish error handling **because the code is going to ship**, you've stopped spiking — promote to `/specify`.
 3. **Write code freely.** Skip tests, skip migrations, skip OpenAPI updates. Hardcode where useful. Use `println` / `logger.info` liberally. Hit real APIs when allowed.
 4. **No production discipline.**
     - Do **not** match JPA vs JDBC patterns — pick whichever is faster to write.
     - Do **not** respect module-by-feature boundaries — put exploration code wherever is easiest.
     - Do **not** worry about backwards compatibility, error handling, or edge cases unless they're *the thing being explored*.
-5. **Write findings to `docs/spikes/<slug>/findings.md`** with this shape:
-    - **Question:** (the input)
-    - **What I tried:** 2–5 bullets
+5. **Write findings to `docs/spikes/<spike-name>/findings.md`** with this shape:
+    - **Goal:** the question, hypothesis, or build target this spike was exploring (the input)
+    - **What I tried:** one bullet per major attempt
     - **What happened:** observations, numbers, errors
     - **Verdict:** Proceed / Abandon / Pivot — one line
     - **Implications:** what this means for the eventual real implementation (links to constraints, gotchas, surprise behaviors)
@@ -36,6 +37,6 @@ If `$ARGUMENTS` is vague (e.g. "spike a thing"), STOP and ask for a specific que
 6. **STOP.** Report:
     - Path of the findings file
     - Verdict in one line
-    - Whether you'd recommend running `/specify --from-spike <slug>` next, or that the spike's answer is "no, don't build this"
+    - Whether you'd recommend running `/specify --from-spike <spike-name>` next, or that the spike's answer is "no, don't build this"
 
 Spike code is **not meant to be merged.** Stay on a spike branch or revert before formalizing into a real spec.

--- a/.claude/commands/spike.md
+++ b/.claude/commands/spike.md
@@ -1,0 +1,41 @@
+---
+description: Throwaway exploratory prototype to validate an idea — no spec, no plan, no tests. Output is a findings document.
+---
+
+# /spike
+
+Run a throwaway exploration to answer a specific question or test a hypothesis. This command intentionally **suppresses** CLAUDE.md's Align → Execute milestone gating — that gate exists to keep production work disciplined, and it would defeat the purpose of a spike.
+
+A spike is not production code. Its only deliverable is **learning**, captured in a findings document.
+
+## Input
+$ARGUMENTS
+
+A specific question or hypothesis. Examples:
+- "Can we extract dependents count from Maven Central without exceeding the solrsearch rate limit?"
+- "Does the OssHealth score still make sense if we drop the issue-velocity component?"
+- "Try PostgreSQL FTS `rank_cd` vs `ts_rank` — which gives better results for our queries?"
+
+If `$ARGUMENTS` is vague (e.g. "spike a thing"), STOP and ask for a specific question.
+
+## Process
+1. **Pick a short kebab-case slug** for the spike (3–6 words).
+2. **Time-box.** A spike is small. If you find yourself touching more than ~5 files, STOP and reconsider — this should probably be a real spec.
+3. **Write code freely.** Skip tests, skip migrations, skip OpenAPI updates. Hardcode where useful. Use `println` / `logger.info` liberally. Hit real APIs when allowed.
+4. **No production discipline.**
+    - Do **not** match JPA vs JDBC patterns — pick whichever is faster to write.
+    - Do **not** respect module-by-feature boundaries — put exploration code wherever is easiest.
+    - Do **not** worry about backwards compatibility, error handling, or edge cases unless they're *the thing being explored*.
+5. **Write findings to `docs/spikes/<slug>/findings.md`** with this shape:
+    - **Question:** (the input)
+    - **What I tried:** 2–5 bullets
+    - **What happened:** observations, numbers, errors
+    - **Verdict:** Proceed / Abandon / Pivot — one line
+    - **Implications:** what this means for the eventual real implementation (links to constraints, gotchas, surprise behaviors)
+    - **Files touched:** path list (so `/specify --from-spike` can find them)
+6. **STOP.** Report:
+    - Path of the findings file
+    - Verdict in one line
+    - Whether you'd recommend running `/specify --from-spike <slug>` next, or that the spike's answer is "no, don't build this"
+
+Spike code is **not meant to be merged.** Stay on a spike branch or revert before formalizing into a real spec.

--- a/.claude/commands/spike.md
+++ b/.claude/commands/spike.md
@@ -15,7 +15,7 @@ A specific question, hypothesis, or build target. Examples (small to large):
 - "Can we extract dependents count from Maven Central without exceeding the solrsearch rate limit?"
 - "Does the OssHealth score still make sense if we drop the issue-velocity component?"
 - "Try PostgreSQL FTS `rank_cd` vs `ts_rank` — which gives better results for our queries?"
-- "Build a rough end-to-end implementation of the OSS health metric per <design doc link> — find out where the design breaks down before we formalize."
+- "Build a rough end-to-end implementation of the OSS health metric per `<design doc link>` — find out where the design breaks down before we formalize."
 
 If `$ARGUMENTS` is vague (e.g. "spike a thing"), STOP and ask for a specific question or build target.
 

--- a/.claude/templates/plan.md
+++ b/.claude/templates/plan.md
@@ -1,0 +1,21 @@
+# Plan: <FEATURE NAME>
+
+**Spec:** [spec.md](spec.md)
+
+## Approach
+1–2 paragraphs. The shape of the solution, not the steps.
+
+## Milestone 1 — <title>
+- **Files:** `path/to/File.kt`, `path/to/Other.kt`
+- **What:** one-sentence change
+- **Validation:** `./gradlew :app:test --tests …` (or a concrete observation, not "manually verify")
+- **Depends on:** —
+
+## Milestone 2 — <title>
+- **Files:** …
+- **What:** …
+- **Validation:** …
+- **Depends on:** Milestone 1
+
+## Open questions carried from spec
+- Copy any unresolved `[NEEDS CLARIFICATION]` markers here so the implementer doesn't lose them.

--- a/.claude/templates/plan.md
+++ b/.claude/templates/plan.md
@@ -1,17 +1,17 @@
-# Plan: <FEATURE NAME>
+# Plan: `<FEATURE NAME>`
 
 **Spec:** [spec.md](spec.md)
 
 ## Approach
 1–2 paragraphs. The shape of the solution, not the steps.
 
-## Milestone 1 — <title>
+## Milestone 1 — `<title>`
 - **Files:** `path/to/File.kt`, `path/to/Other.kt`
 - **What:** one-sentence change
 - **Validation:** `./gradlew :app:test --tests …` (or a concrete observation, not "manually verify")
 - **Depends on:** —
 
-## Milestone 2 — <title>
+## Milestone 2 — `<title>`
 - **Files:** …
 - **What:** …
 - **Validation:** …

--- a/.claude/templates/spec.md
+++ b/.claude/templates/spec.md
@@ -63,14 +63,33 @@ Explicit list.
 ## 9. Key entities (only if data model changes)
 - **<EntityName>:** purpose, key fields, relationships, lifecycle
 
-## 10. Test strategy
+## 10. Database schema diagram (only if schema changes)
+*Mermaid ER diagram of the resulting tables. Mark new tables/columns with `(new)`, removed ones with `(removed)`. Skip if schema is unchanged. Renders natively in GitHub and IntelliJ.*
+
+```mermaid
+erDiagram
+    PROJECT ||--o{ PROJECT_CATEGORY : has
+    CATEGORY ||--o{ PROJECT_CATEGORY : tags
+    CATEGORY {
+        bigint id PK
+        string name
+        bigint parent_id FK "(new)"
+    }
+    PROJECT_CATEGORY {
+        bigint project_id FK
+        bigint category_id FK
+        float confidence "(new)"
+    }
+```
+
+## 11. Test strategy
 - **Unit:** which classes, mocking boundary
 - **DB-integration:** `BaseUnitWithDbLayerTest` subclasses; method-level `@Sql` seeds
 - **Web / smoke:** `SmokeTestBase` for new endpoints
 - *Reviewer-only — manual / staging:* what to verify on `klibs-features` / `klibs-stage`
 
-## 11. Assumptions
+## 12. Assumptions
 - …
 
-## 12. References
+## 13. References
 - Design docs, related specs, prior art

--- a/.claude/templates/spec.md
+++ b/.claude/templates/spec.md
@@ -1,0 +1,76 @@
+# Spec: [FEATURE NAME]
+
+**Input:** verbatim seed text — preserved for traceability
+
+## 1. Goal
+One or two sentences.
+
+## 2. Problem
+- What's broken / missing today?
+- Who's affected (end users, library authors, developers)?
+
+## 3. User scenarios & acceptance
+### Scenario 1 — <title> (P1)
+- **Given:** <state>
+- **When:** <action>
+- **Then:** <observable outcome>
+- **Independent test:** <how to verify in isolation>
+
+### Edge cases
+- What happens when <boundary>?
+- How does the system handle <error / partial failure>?
+
+## 4. Functional requirements
+- **FR-001:** System MUST …
+- **FR-002:** System MUST NOT …
+- Mark unknowns inline: `[NEEDS CLARIFICATION: …]`
+
+## 5. Non-functional requirements
+*Include only what applies; cut the rest.*
+- **Performance:** latency budget, throughput, dataset size
+- **External rate limits:** GitHub, Maven Central (repo1 / solrsearch / central.sonatype), OpenAI, S3 — per-IP budgets, klibs egress IPs shared across replicas
+- **Concurrency:** scheduling, ShedLock keys, race windows
+- **Observability:** new logs / metrics / alerts
+- **Security:** auth boundary, token scopes
+
+## 6. Out of scope
+Explicit list.
+
+## 7. Klibs.io technical surface
+*Mark only lines that apply.*
+- **Modules touched:** e.g. `app`, `core/scm-repository`, `integrations/github`
+- **Database:** new tables / columns / indexes; migration folder (`db/migration/<YYYY>-Q<n>/`); additive-only? backfill plan?
+- **Persistence style:** JPA vs raw JDBC — match the existing pattern in the touched module
+- **Search / materialized views:** `project_index` / `package_index` impact
+- **External integrations:** APIs called; request volume; retry / backoff
+- **Scheduled jobs:** new `@Scheduled`; ShedLock lock names; cadence; idempotency
+- **Storage:** S3 prefixes; local cache invalidation
+- **Configuration:** new `klibs.*` properties; profile defaults; feature-flag toggle?
+- **API surface:** new/changed endpoints; OpenAPI doc; breaking change?
+- **Frontend contract:** does `klibs-frontend` need to change?
+
+## 8. Design options considered
+*Skip when the implementation is the only sensible one.*
+
+### Option A — <name>
+- Approach / pros / cons
+
+### Option B — <name>
+- …
+
+**Decision:** Option <X>. Rationale: …
+
+## 9. Key entities (only if data model changes)
+- **<EntityName>:** purpose, key fields, relationships, lifecycle
+
+## 10. Test strategy
+- **Unit:** which classes, mocking boundary
+- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses; method-level `@Sql` seeds
+- **Web / smoke:** `SmokeTestBase` for new endpoints
+- *Reviewer-only — manual / staging:* what to verify on `klibs-features` / `klibs-stage`
+
+## 11. Assumptions
+- …
+
+## 12. References
+- Design docs, related specs, prior art

--- a/.claude/templates/spec.md
+++ b/.claude/templates/spec.md
@@ -10,15 +10,15 @@ One or two sentences.
 - Who's affected (end users, library authors, developers)?
 
 ## 3. User scenarios & acceptance
-### Scenario 1 — <title> (P1)
-- **Given:** <state>
-- **When:** <action>
-- **Then:** <observable outcome>
-- **Independent test:** <how to verify in isolation>
+### Scenario 1 — `<title>` (P1)
+- **Given:** `<state>`
+- **When:** `<action>`
+- **Then:** `<observable outcome>`
+- **Independent test:** `<how to verify in isolation>`
 
 ### Edge cases
-- What happens when <boundary>?
-- How does the system handle <error / partial failure>?
+- What happens when `<boundary>`?
+- How does the system handle `<error / partial failure>`?
 
 ## 4. Functional requirements
 - **FR-001:** System MUST …
@@ -52,16 +52,16 @@ Explicit list.
 ## 8. Design options considered
 *Skip when the implementation is the only sensible one.*
 
-### Option A — <name>
+### Option A — `<name>`
 - Approach / pros / cons
 
-### Option B — <name>
+### Option B — `<name>`
 - …
 
-**Decision:** Option <X>. Rationale: …
+**Decision:** Option `<X>`. Rationale: …
 
 ## 9. Key entities (only if data model changes)
-- **<EntityName>:** purpose, key fields, relationships, lifecycle
+- **`<EntityName>`:** purpose, key fields, relationships, lifecycle
 
 ## 10. Database schema diagram (only if schema changes)
 *Mermaid ER diagram of the resulting tables. Mark new tables/columns with `(new)`, removed ones with `(removed)`. Skip if schema is unchanged. Renders natively in GitHub and IntelliJ.*

--- a/.claude/templates/spec.md
+++ b/.claude/templates/spec.md
@@ -1,7 +1,5 @@
 # Spec: [FEATURE NAME]
 
-**Input:** verbatim seed text — preserved for traceability
-
 ## 1. Goal
 One or two sentences.
 
@@ -21,8 +19,15 @@ One or two sentences.
 - How does the system handle `<error / partial failure>`?
 
 ## 4. Functional requirements
+*An FR is an **observable contract**: what the system does, seen from outside. Before writing each one, apply the litmus — **could a black-box test or an API consumer detect a violation?** If no, it is a design decision, not a requirement: it belongs in §8, not here.*
+
+*FRs never name an internal mechanism (a table, job, cache, library, query shape). The tell:*
+- *✗ "System MUST NOT use a daily snapshot table" — no outside observer can detect this. It's a how. → §8.*
+- *✓ "System MUST distinguish "not yet computed" from a score of 0 in the response" — a consumer can read the field and tell. → stays here.*
+
+*`MUST NOT` is for **observable prohibitions** only (e.g. "MUST NOT expose draft projects to unauthenticated callers"), never for internal-mechanism bans.*
 - **FR-001:** System MUST …
-- **FR-002:** System MUST NOT …
+- **FR-002:** System MUST …
 - Mark unknowns inline: `[NEEDS CLARIFICATION: …]`
 
 ## 5. Non-functional requirements
@@ -39,7 +44,7 @@ Explicit list.
 ## 7. Klibs.io technical surface
 *Mark only lines that apply.*
 - **Modules touched:** e.g. `app`, `core/scm-repository`, `integrations/github`
-- **Database:** new tables / columns / indexes; migration folder (`db/migration/<YYYY>-Q<n>/`); additive-only? backfill plan?
+- **Database:** entities and their key fields, relationships, identity strategy, status enums, nullability — the *data model*. Column types, index choice, and exact column naming are migration choices and belong in the plan. Note migration folder (`db/migration/<YYYY>-Q<n>/`), additive-only?, backfill plan?
 - **Persistence style:** JPA vs raw JDBC — match the existing pattern in the touched module
 - **Search / materialized views:** `project_index` / `package_index` impact
 - **External integrations:** APIs called; request volume; retry / backoff
@@ -49,16 +54,14 @@ Explicit list.
 - **API surface:** new/changed endpoints; OpenAPI doc; breaking change?
 - **Frontend contract:** does `klibs-frontend` need to change?
 
-## 8. Design options considered
-*Skip when the implementation is the only sensible one.*
+## 8. Design decisions
+*The home for every "how / which mechanism" choice — including the ones the §4 litmus rejected (internal tables, jobs, caches, libraries, query shapes, which-of-two-approaches). Record a decision even when there's only one option on the table — a choice with no stated alternative is still worth writing down so a reviewer can challenge it. Skip the section only if there were genuinely no choices to make.*
 
-### Option A — `<name>`
-- Approach / pros / cons
-
-### Option B — `<name>`
-- …
-
-**Decision:** Option `<X>`. Rationale: …
+### Decision — `<what was decided>`
+- **Choice:** `<the mechanism / approach chosen>`
+- **Why:** `<rationale>`
+- **Rejected:** `<alternative(s) and why not>` — for a genuine multi-way trade-off, list each. Omit only if there was no real alternative.
+- **Revisit if:** `<the condition that would flip this>` — optional
 
 ## 9. Key entities (only if data model changes)
 - **`<EntityName>`:** purpose, key fields, relationships, lifecycle

--- a/docs/specs/oss-health-metric-v0/spec-old.md
+++ b/docs/specs/oss-health-metric-v0/spec-old.md
@@ -1,0 +1,200 @@
+# Spec: OSS Health Metric
+
+## 1. Goal
+Compute and expose a per-project **OSS Health** score (0–100) — a composite, research-backed signal of repository activity and responsiveness — so that visitors of a klibs.io project page can judge whether a library is actively maintained without needing to skim GitHub themselves.
+
+## 2. Problem
+- klibs.io currently exposes only point-in-time GitHub fields per repository: `stars`, `open_issues`, `last_activity_ts`, `license`. None of these on their own tell a visitor whether a library is being actively maintained — a high-star library can be abandoned, a low-star one can be healthy.
+- The research the RFC cites ([Iqbal et al., 2023](https://arxiv.org/abs/2309.12120v3)) shows that single raw indicators (stars, commit recency, issue counts) do not reliably identify OSS sustainability. A composite is needed.
+- **Affected:** end users of klibs.io evaluating library trustworthiness; library maintainers who want a neutral, defensible signal of their project's activity surfaced on the platform.
+
+## 3. User scenarios & acceptance
+
+### Scenario 1 — Visitor sees health on a project page (P1)
+- **Given:** a project whose backing GitHub repo has at least 12 weeks of recorded activity and the OSS Health score has been computed.
+- **When:** the visitor opens the project details page (`/project/{ownerLogin}/{projectName}/details`).
+- **Then:** the response includes an `ossHealth` field with an integer 0–100, plus the timestamp at which it was last computed.
+- **Independent test:** seed `scm_repo` + an `oss_health_score` row with a fixture score; call the details endpoint; assert `ossHealth` is present and within [0, 100].
+
+### Scenario 2 — Insufficient data is reported, not hidden silently (P1)
+- **Given:** a project whose backing repo has fewer than 12 weeks of recorded commit/issue/PR activity, OR whose score has not yet been computed.
+- **When:** the visitor opens the project details page.
+- **Then:** `ossHealth` is `null` and the response carries a status (see FR-008) so the frontend can render *"Insufficient activity data"* rather than a misleading "0".
+- **Independent test:** seed a brand-new repo with one commit; assert the field is `null`/insufficient and not `0`.
+
+### Scenario 3 — Health stays fresh (P1)
+- **Given:** a project whose score was last computed more than the eligibility window ago (default 7 days).
+- **When:** time passes and the recompute runs.
+- **Then:** the score is recomputed from the latest 12-week window of commit/issue/PR data and the stored `computed_at` moves forward, so a returning visitor never sees a score staler than the window.
+- **Independent test:** seed a score row with an old `computed_at`; run the recompute against a stubbed `GitHubIntegration`; assert the row is upserted with a fresh `computed_at`.
+
+### Scenario 4 — Recompute yields under rate-limit pressure (P1)
+- **Given:** the recompute is about to process a repo, and the remaining GitHub API budget is below the safety margin.
+- **When:** it runs.
+- **Then:** it makes no GitHub call; the repo's `computed_at` is left untouched so it remains eligible later; a `oss_health_skipped_rate_limit_total` counter increments.
+- **Independent test:** run the recompute with a fake `GitHubIntegration.getRateLimitInfo()` returning `remaining < safetyMargin`; assert no API call is made and the score row is unchanged.
+
+### Edge cases
+- **Repo younger than 12 weeks:** report insufficient data. Do not extrapolate (per RFC's "negative impact risk" note — a misleadingly low score is worse than no score).
+- **Repo with zero issues / zero PRs over the window:** the Issue and PR sub-scores have undefined ratios. The ratio term contributes `0` but the median term keeps its full weight — see FR-006.
+- **Repo with one contributor:** `TopContributorCommitShare = 1.0`, so the diversity sub-score becomes `0.6 * (1/5) + 0.4 * 0 = 0.12`. This is intended; a one-person project legitimately scores low on diversity.
+- **Archived / disabled GitHub repo:** no score is computed or shown. If a score row already exists, it transitions to `status = NOT_APPLICABLE` with a null `score` — see FR-010.
+- **Repository renamed / transferred:** the `nativeId` (numeric repo ID) is stable across renames; the score keys on `scm_repo.id` (derived from `nativeId`), not on `owner/name`.
+
+## 4. Functional requirements
+
+- **FR-001:** System MUST compute an OSS Health score in `[0, 100]` per scm-repository, defined as `100 * (0.30*C + 0.25*I + 0.25*P + 0.20*A)`, where the four sub-scores `C, I, P, A ∈ [0, 1]` are computed per FR-002–FR-005.
+- **FR-002:** System MUST compute `C` (Commit Consistency) over the last 12 weeks of weekly commit buckets as `C = max(0, 1 - CV / 0.6)` where `CV = stdev(weekly_commits) / mean(weekly_commits)`. If `mean == 0`, then `C = 0` (no commits = no consistency).
+- **FR-003:** System MUST compute `I` (Issue Responsiveness) as `I = 0.5 * min(1, IssueCloseRatio / 0.4) + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)`, where:
+    - `IssueCloseRatio = issues_closed_in_window / issues_opened_in_window`. An issue counts as "opened in window" if `createdAt >= now-12w`; "closed in window" if it is closed and `closedAt >= now-12w`.
+    - `MedianIssueCloseDays = median(closedAt - createdAt)` in days, over issues closed in the window.
+- **FR-004:** System MUST compute `P` (PR Management) as `P = 0.5 * min(1, PRMergeRatio / 0.5) + 0.5 * max(0, 1 - MedianPRMergeDays / 14)`, where:
+    - `PRMergeRatio = prs_merged_in_window / prs_opened_in_window`. A PR closed without merge counts in the denominator but **not** the numerator (per the RFC).
+    - `MedianPRMergeDays = median(mergedAt - createdAt)` in days, over PRs *merged* in the window.
+- **FR-005:** System MUST compute `A` (Author Diversity) as `A = 0.6 * min(1, ActiveContributors / 5) + 0.4 * (1 - TopContributorCommitShare)`, where `ActiveContributors` is the count of distinct commit authors with ≥ 1 commit in the last 12 weeks and `TopContributorCommitShare = top_committer_commits / total_commits` in that window. If `total_commits == 0`, then `ActiveContributors = 0`, `TopContributorCommitShare = 0`, and `A = 0`.
+- **FR-006:** System MUST treat *missing* sub-component inputs distinctly from *zero* inputs. If a repo had zero issues opened in the window, the `IssueCloseRatio` ratio term contributes `0` (no issues to respond to) but the median term keeps its full `1.0` weight (there were no slow closes). Same for PRs. The formula's `min(1, …)` / `max(0, …)` clamps already produce this; this requirement freezes the intent so a future change can't silently zero out the whole `I` or `P`.
+- **FR-007:** System MUST require **at least 12 weeks** of repository history (since `created_at`) before producing a numeric score. A repo younger than 12 weeks MUST be reported as `INSUFFICIENT_DATA`, not scored.
+- **FR-008:** System MUST distinguish "score not yet computed" / "insufficient data" / "not applicable" from a real score of `0`. The API `ossHealth` field is nullable, and the details response carries a status of `OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`.
+- **FR-009:** System MUST keep a computed score fresh: once a score's last-computed time is older than the eligibility window (default 7 days), the system MUST recompute it from the current 12-week window. A returning visitor MUST never see a score staler than the window plus one recompute cycle.
+- **FR-010:** System MUST NOT compute or display an OSS Health score for archived or disabled GitHub repositories. A previously-computed score for a repo that has since been archived MUST transition to `status = NOT_APPLICABLE` with a null `score`.
+- **FR-011:** System MUST expose `ossHealth` on **both** API surfaces: `ProjectDetailsDTO` (nullable integer `ossHealth` plus an `ossHealthStatus`) and `SearchProjectResult` (nullable integer `ossHealth` only — a `null` is the "do not show" signal for the listing; the status enum is not exposed in search results).
+- **FR-012:** System MUST allow the score computation to be disabled via configuration, independently per environment, without removing already-computed scores from the read path.
+
+## 5. Non-functional requirements
+
+- **Performance:** Score computation is offline (job-driven), not request-time. The API read path (`/project/.../details`) MUST add no more than a single indexed lookup on the score table (or a join on `scm_repo_id`). No GitHub API call on the read path.
+- **External rate limits:**
+    - GitHub GraphQL: per-repo cost is **3 GraphQL queries** (commits → C + A, issues → I, PRs → P), each potentially paginated. GraphQL has a complexity-points budget of 5,000 pts/hr per token; each non-paginated query costs ~1 pt and each additional page adds proportionally. Even at a pessimistic ~30 pts/repo, the shared NAT pool comfortably accommodates ~150 repos/hr — well above what the recompute actually consumes.
+    - The recompute paces at roughly one repo per ~30s (⇒ ~120 repos/hr; see the drip decision in §8), keeping comfortable headroom for the existing 30-second `GitHubRepositoryUpdatingJob`, which shares the same PAT + NAT egress. `klibs-stage` and `klibs-features` share a single GKE Cloud NAT pool, so the GitHub rate-limit budget is per-egress-IP, not per-replica — both jobs draw from the same bucket.
+    - The job MUST check `GitHubIntegration.getRateLimitInfo()` (extended to surface GraphQL points if not already exposed there) and skip the iteration if `remaining < safetyMargin` (default 200), deferring the repo to a later tick.
+- **Concurrency:** One new ShedLock key: `computeOssHealthLock`. The recompute and the existing `updateGitHubRepositoryLock` job both call GitHub and share the same PAT + NAT egress; the per-iteration rate-limit guard above keeps them out of each other's way.
+- **Observability:**
+    - Micrometer counter per new GraphQL query type (`oss_health.graphql.commits`, `oss_health.graphql.issues`, `oss_health.graphql.pulls`) plus pagination-page counters, consistent with the per-request-type pattern already in `GitHubIntegrationKohsukeLibrary`.
+    - Counters / gauges for `oss_health_compute_success_total`, `oss_health_compute_failure_total{reason}`, `oss_health_insufficient_data_total`, `oss_health_skipped_archived_total`, `oss_health_skipped_rate_limit_total`.
+    - INFO log line per repo with the four sub-scores so a surprising final number can be debugged without re-running.
+- **Security:** Read-only endpoint addition (no auth boundary change). The score is non-sensitive aggregate metadata. Contributor logins fetched from GitHub are used only for the `ActiveContributors` count and `TopContributorCommitShare` aggregation; no GitHub logins are persisted (we store only the resulting numeric `a_component`).
+
+## 6. Out of scope
+
+- Author-facing analytics (the P3 items in the RFC: page views, snippet copies, outbound clicks, search impressions/clicks). Those depend on the GitHub OAuth flow described in the RFC's "Authentication" section — separate spec.
+- Number-of-dependents (P1 in the RFC) — already in the codebase (`project.dependent_count`). Not part of this spec.
+- Maven downloads, pub.dev–style Likes/Points, trending. Not in this spec.
+- Repository-centrality network analysis (arXiv 2405.07508). Explicitly rejected by the RFC as "too much computation for klibs purposes."
+- Applying a display cutoff server-side (the RFC suggests "show only if ≥ 40, else *Insufficient activity data*"). The **backend always returns the score**; the **display cutoff is a frontend concern**, enabled by the `status` enum (FR-008).
+- Showing more than `ossHealth` on search results — the listing surfaces the integer score only (or hides it on `null`). The status enum is details-page-only (FR-011).
+- A health-over-time trend / history feature. The current design stores only the latest score (see the re-query decision in §8); trend would require stored history.
+
+## 7. Klibs.io technical surface
+
+- **Modules touched:**
+    - `core/scm-repository` — new sub-package `oss-health` (or a sibling module `core/oss-health`) housing the `OssHealthScore` JPA entity, repository, and the calculator. Keeps concerns out of `ScmRepositoryEntity` itself.
+    - `integrations/github` — new GraphQL-backed methods on `GitHubIntegration`: `getCommitsSince(repositoryId, since): List<CommitMeta>` (returns `committedDate` + `authorLogin`), `getIssuesActivitySince(repositoryId, since): List<IssueActivity>` (`createdAt`, `closedAt`, `state`), `getPullRequestsActivitySince(repositoryId, since): List<PrActivity>` (`createdAt`, `mergedAt`, `closedAt`, `state`). The existing Kohsuke client is REST-only; the GraphQL queries go through the existing OkHttp + GitHub PAT path. New per-query micrometer counters.
+    - `app` — new scheduled recompute job; new Liquibase migration; wiring in `ProjectDetailsService` and the search-results assembly path to surface the score.
+    - `core/project` — additive change to `ProjectDetailsDTO`.
+    - `core/search` — additive change to `SearchProjectResult` and the `project_index` materialized-view SQL.
+- **Database:**
+    - New JPA-managed entity `OssHealthScore` — one row per `scm_repo`, keyed by `scm_repo_id` (FK to `scm_repo`). Fields: a nullable integer `score` in `[0, 100]`; a `status` enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`); the four sub-components (`c`, `i`, `p`, `a`) as fractional values in `[0, 1]`; and a nullable `computed_at` timestamp. The sub-components are persisted alongside the final score so a future "why is my score X?" breakdown is a join, not a recompute. Column types, indexes, and exact naming are decided in the migration.
+    - Additive change to the `project_index` materialized view: gain a nullable `oss_health` integer column, sourced from a `LEFT JOIN` on `OssHealthScore` keyed by `scm_repo_id`. The `LEFT JOIN` keeps the view null-tolerant for repos with no score yet.
+    - Migration folder: `app/src/main/resources/db/migration/2026-Q2/` (current quarter per the survey).
+    - Additive-only: yes. No backfill of historical data needed — the recompute pulls the last 12 weeks of history in one shot, so a mature repo can be scored on its first eligible recompute post-deploy.
+- **Persistence style:** **JPA + HQL** for the new `oss_health_score` table. Rationale per maintainer guidance: HQL gives compile-time-checked queries against the JPA model and a stronger validation surface than raw JDBC, and there's no high-throughput hot-path on this table (one read per details fetch — served via the materialized view for search — and one upsert per repo per eligibility window).
+- **Search / materialized views:**
+    - `project_index` gains a nullable `oss_health` column via a `LEFT JOIN` on the new `oss_health_score` table. Refresh cadence is unchanged (the existing 10-minute `MaterializedViewUpdatingJob` picks it up via `REFRESH MATERIALIZED VIEW CONCURRENTLY`). Changing a materialized view's defining SELECT requires a drop + create; confirm at implementation time whether that lands as a new changeset or an inline edit, since a checksum-dodging follow-up changeset is not the default here.
+    - `package_index` is unaffected (per-package, not per-project).
+- **External integrations:**
+    - GitHub GraphQL API (single endpoint `https://api.github.com/graphql`). Three queries per repo per recompute: `repository.defaultBranchRef.target ... on Commit { history }` (commits over 12 weeks), `repository.issues(filterBy: { since: ... })` (issue activity), `repository.pullRequests(orderBy: UPDATED_AT)` (PR activity). All paginate via standard `pageInfo { endCursor hasNextPage }`. (Why GraphQL and not the REST stats endpoints: see §8.)
+    - Standard 5xx / secondary-rate-limit retry-after handling applies.
+    - Authentication uses the existing `klibs.integration.github.personalAccessToken`. Scope: `public_repo` is sufficient.
+- **Scheduled jobs:**
+    - One new job: `OssHealthComputeJob`, `@Scheduled(fixedRate = 30s, initialDelay = 30s)` (rate configurable via `klibs.oss-health.fixed-rate-ms`). ShedLock name `computeOssHealthLock`. Each iteration picks the single staleest eligible repo (`oss_health_score.computed_at IS NULL OR < now() - <eligibility window>` AND repo is not archived/disabled), runs the three GraphQL queries, computes, and upserts. One repo per iteration — no batch fan-out (see the drip decision in §8).
+    - The existing `GitHubRepositoryUpdatingJob` is unchanged.
+    - Idempotency: upsert keyed by `scm_repo_id`. Re-running for the same repo within the same eligibility window yields an identical score (deterministic computation from the same 12-week window).
+- **Storage:** No S3 / no local cache impact. README handling is untouched.
+- **Configuration:** New `klibs.oss-health.*` properties — `enabled: Boolean = true`, `fixed-rate-ms: Long = 30_000`, `eligibility-window-days: Int = 7`, `rate-limit-safety-margin: Int = 200`. Profile defaults: enabled in `local` and `prod`; disabled in `test` via a default-on property overridden in `application-test.yml` (not via `@Profile`). Mirrors the existing `klibs.indexing` toggle pattern.
+- **API surface:** Additive changes to **two** DTOs: `ProjectDetailsDTO` gains nullable `ossHealth: Int?` and `ossHealthStatus` (enum); `SearchProjectResult` gains nullable `ossHealth: Int?` (status omitted — `null` is the "do not show" signal). OpenAPI doc auto-regenerates. **Not** a breaking change.
+- **Frontend contract:** `klibs-frontend` needs to:
+    1. Render the new field on **both** the project-details page (using `ossHealth` + `ossHealthStatus`) and the search-results listing (using `ossHealth` only — render nothing when null).
+    2. On the details page, apply the RFC's "show only if ≥ 40, else *Insufficient activity data*" rule client-side, driven by the `ossHealthStatus` enum.
+    3. Optionally render a tooltip explaining the four sub-scores (the breakdown is stored server-side; a future `/oss-health/{projectId}/breakdown` endpoint is cheap to add — out of scope for v1).
+
+## 8. Design decisions
+
+### Decision — Normalization form and frozen weights
+- **Choice:** Use the RFC's simplified linear-with-clamps normalization — `min(1, x / threshold)` for "more is better" terms, `max(0, 1 - y / threshold)` for "less is better" terms — with the four CSI weights `0.30 / 0.25 / 0.25 / 0.20` and the RFC's thresholds (`IssueCloseRatio / 0.4`, `MedianIssueCloseDays / 21`, `PRMergeRatio / 0.5`, `MedianPRMergeDays / 14`, `ActiveContributors / 5`). These weights and thresholds are normative; changing them is a spec amendment, not an implementation tweak.
+- **Why:** Monotonic and explainable — "more closed issues is always better, up to the cap"; the thresholds are concrete and reviewable here rather than buried in a paper's appendix. Defensible to an author asking "why did my score drop?"
+- **Rejected:**
+    - *Paper-faithful CSI with triangular membership functions* (arXiv 2504.00542): the paper is self-described as "conceptual," empirical validation pending, and triangular functions are non-monotonic — a repo can score *worse* by committing *more* than the target, which is counterintuitive and hard to explain.
+    - The Iqbal et al. paper (arXiv 2309.12120v3) the RFC cites supports a *composite over single signals* but prescribes no specific constants, so any threshold choice is a judgment call regardless.
+- **Revisit if:** the scores prove poorly calibrated against a hand-labeled sample of known-healthy / known-abandoned repos.
+
+### Decision — Precompute and persist, not compute-on-demand
+- **Choice:** Compute the score offline in a job and persist it; the read path only reads.
+- **Why:** Keeps GitHub off the request path; the score is precisely the kind of value you want cached, not recomputed per page view.
+- **Rejected:** *On-demand compute, cache in-process* — minimal schema change, but the hot path then depends on GitHub availability, and the shared-NAT rate limits make it fragile under traffic. Defeats the premise of a precomputed signal.
+
+### Decision — Stateless full-window re-query, not an incremental rolling buffer
+- **Choice:** On each recompute, re-query the full trailing 12-week window from GitHub. Store only the latest score, no per-day/per-week history.
+- **Why:** Stateless and self-healing — a missed run just leaves a stale row that the next run repairs; no accumulation, gap-handling, or backfill logic. The GraphQL query is itself a sliding window (`since` advances each run). §5's headroom analysis shows the per-recompute cost is affordable at current scale.
+- **Rejected:** *Incremental rolling buffer* (the RFC's "daily snapshot" instinct: append the newest week's counts, drop the aged-out one). Cheaper per run, but stateful — a missed run or gap corrupts the window and needs backfill. Only worth it if re-query cost becomes a real constraint.
+- **Revisit if:** repo count grows ~10× (re-query cost bites), **or** a health-over-time trend feature is wanted (which needs the stored history this design omits).
+
+### Decision — Drip job (one repo per iteration), not a batch cron
+- **Choice:** A `@Scheduled` task that processes exactly one eligible repo per iteration, picking the staleest, rather than a single periodic job that recomputes all repos at once.
+- **Why:** Spreads the GitHub API draw evenly over time instead of bursting at one cron tick, leaving headroom for the existing 30-second `GitHubRepositoryUpdatingJob` on the same shared PAT + NAT egress. No big-bang contention. The freshness contract (FR-009) is satisfied as long as the drip cycles through all eligible repos within the eligibility window.
+- **Rejected:** *Batch weekly cron* — simpler to reason about, but concentrates the entire API draw into one window and contends with the existing job on the shared rate-limit budget.
+
+### Decision — GitHub GraphQL, not the REST stats endpoints
+- **Choice:** Derive commit buckets, contributor share, and issue/PR activity from GraphQL queries (`repository.defaultBranchRef.target … history`, `repository.issues`, `repository.pullRequests`).
+- **Why:** REST `/stats/participation` and `/stats/contributors` return `HTTP 202 Accepted` on cold reads with no firm completion ceiling, making them unreliable for an automated job. GraphQL returns the same deterministic shape on every call and consolidates commit history + author logins into a single query (covering both C and A).
+- **Rejected:** *REST stats endpoints* — the 202-stall behavior is a non-starter for unattended computation.
+
+## 9. Key entities
+
+- **OssHealthScore:** one row per `scm_repo`. JPA-managed. Stores the final integer score, the four sub-components (`c, i, p, a` as numeric for debugging), a status enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`), and a `computed_at` timestamp. Lifecycle: created lazily on first successful recompute for a repo; refreshed when `computed_at` becomes older than the eligibility window; transitions to `NOT_APPLICABLE` if the parent repo is archived/disabled; deleted only if the parent `scm_repo` is deleted (cascade).
+
+## 10. Database schema diagram
+
+```mermaid
+erDiagram
+    SCM_REPO ||--o| OSS_HEALTH_SCORE : has
+    OSS_HEALTH_SCORE {
+        bigint scm_repo_id PK "FK to scm_repo (new)"
+        int score "nullable, 0-100 (new)"
+        string status "OK|INSUFFICIENT_DATA|STALE|NOT_APPLICABLE (new)"
+        decimal c_component "0-1 (new)"
+        decimal i_component "0-1 (new)"
+        decimal p_component "0-1 (new)"
+        decimal a_component "0-1 (new)"
+        timestamp computed_at "nullable (new)"
+    }
+    PROJECT_INDEX {
+        bigint project_id
+        int oss_health "nullable (new column)"
+    }
+```
+
+*`PROJECT_INDEX` is a materialized view; the new column is added via an updated defining `SELECT` with a `LEFT JOIN` on `oss_health_score`. Field types shown are illustrative — concrete types are chosen in the migration.*
+
+## 11. Test strategy
+
+- **Unit:**
+    - `OssHealthCalculator` (pure function from `(weeklyCommits, openedClosedIssueCounts, medianIssueDays, openedClosedPrCounts, medianPrDays, activeContributors, topShare) -> Int score + components`). Test the formula edge cases: zero commits (C=0), zero issues, zero PRs, single contributor, perfectly balanced repo. Cover the FR-006 "missing vs zero" semantics with explicit cases.
+    - Recompute-iteration unit test (with mocked `GitHubIntegration`) that verifies: (a) rate-limit yield (Scenario 4) defers the repo without state change, (b) an archived/disabled repo is excluded without an API call, (c) idempotency — running the same iteration twice produces identical score rows.
+- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses for the new `OssHealthScore` JPA repository. Use method-level `@Sql` seeds — a class-level `@Sql` breaks the inherited per-method truncate in `BaseUnitWithDbLayerTest`. Verify upsert idempotency and that the `project_index` materialized-view refresh picks up new score rows via the `LEFT JOIN`.
+- **Web / smoke:** `SmokeTestBase` test that hits `/project/.../details` against a seeded fixture and asserts the new fields appear in the JSON response with the expected shape (null case and populated case). A second `SmokeTestBase` test on the search endpoint asserts `ossHealth` is present in `SearchProjectResult` JSON.
+- *Reviewer-only — manual / staging:* deploy to `klibs-features` (not prod), let the recompute run for a few hours, watch the new counters in the actuator output, spot-check 3–5 known repos (one obviously healthy, one obviously abandoned, one new) and confirm the scores feel directionally right. Compare against GraphQL points-budget headroom on the shared NAT IP pool.
+
+## 12. Assumptions
+
+- Per-repo GraphQL pagination is capped at ~3 pages (≤ 300 items) per query for issues and PRs. If a repo has more than 300 closed issues / PRs in 12 weeks, the median over the first 300 is a fine approximation; commit-history pagination is uncapped (we need all commits in the window for accurate weekly buckets and contributor share, but in practice 12 weeks of commits stays well within a handful of pages for typical klibs libraries).
+- **No cold-start warmup:** because the queries pull the last 12 weeks of history directly, a mature repo can be scored on its first eligible recompute post-deploy. Only repos with `scm_repo.created_at > now - 12 weeks` are `INSUFFICIENT_DATA` (FR-007).
+- Display semantics (`≥ 40 ⇒ show number`, `< 40 ⇒ show "Insufficient activity data"`) are a frontend concern. The backend always returns the raw number when computable; the `ossHealthStatus` enum is the contract. This separation lets us tune the display cutoff later without re-deploying the backend.
+- The numeric `nativeId` of a GitHub repo is stable across renames/transfers (GitHub's documented behavior); we key the new table off `scm_repo.id`, which already keys off `nativeId`.
+
+## 13. References
+
+- RFC, source of truth for this spec: `KTL-4246 Exploratory research for author-faced insights` (the OSS Health index section). [NEEDS CLARIFICATION: the spec currently cites this by a local download path; copy the relevant section into `docs/specs/oss-health-metric/rfc.md` so the reference is repo-resolvable.]
+- *Introducing Repository Stability* — arXiv [2504.00542](https://arxiv.org/abs/2504.00542) (2025). Source of the CSI formula structure (weights 0.30 / 0.25 / 0.25 / 0.20). Paper acknowledges its "conceptual phase" status; we adopt the four-dimension structure but **not** its triangular-membership normalization (see §8).
+- *Individual context-free online community health indicators fail to identify open source software sustainability* — arXiv [2309.12120v3](https://arxiv.org/abs/2309.12120v3) (2023, rev. 2024). Motivates the composite-over-single-metric choice; cited in problem statement.
+- *Revealing the value of Repository Centrality in lifespan prediction of OSS Projects* — arXiv [2405.07508](https://arxiv.org/abs/2405.07508) (2024). Explicitly out of scope per the RFC (too compute-heavy).
+- Existing klibs.io entities referenced: `ScmRepositoryEntity` (`core/scm-repository`), `ProjectDetailsDTO` (`core/project`), `GitHubIntegration` (`integrations/github`), `project_index` materialized view (`core/search`).

--- a/docs/specs/oss-health-metric/plan.md
+++ b/docs/specs/oss-health-metric/plan.md
@@ -1,0 +1,39 @@
+# Plan: `oss-health-metric`
+
+**Spec:** [spec.md](spec.md)
+
+## Approach
+
+Build the feature bottom-up in four independently-mergeable slices. The **data model + pure formula** land first (a new `oss_health` table, a JPA entity/repository, and a side-effect-free `OssHealthCalculator`) — fully testable in isolation with no external calls. In parallel, the **GitHub GraphQL fetch** is added to `integrations/github` as a self-contained capability returning its own activity model, with no dependency on `core`. The **scheduled job** in `app` then wires the two together (it owns the mapping from the GitHub activity model to the calculator's input contract, the skip/insufficient logic, persistence, backoff, and metrics). Finally, **API exposure** recreates `project_index` to carry the raw score + status and adds the gated `ossHealth` field to the search and project-details DTOs.
+
+Module boundaries are kept clean: `integrations/github` stays free of `core`, the calculator's input type lives in `core/scm-repository`, and `app` does the cross-module mapping (the existing "app orchestrates" pattern). The raw score is persisted and stored in the view; the `< 40` cutoff is applied only at DTO assembly (per §8). Note for M1: the new JPA entity/repository package must be covered by the app's entity/repository scanning (the module is otherwise JDBC) — verify alongside the existing JPA-based `core/package`.
+
+## Milestone 1 — OSS Health data model + score calculator
+- **Files:** `app/src/main/resources/db/migration/2026-Q2/2026-06-01_create_oss_health_table.yml` (+ register in `db.changelog-master.yml`); `core/scm-repository/.../health/{OssHealthEntity,OssHealthStatus,OssHealthRepository,RepositoryActivityInput,OssHealthCalculator}.kt`; tests `OssHealthCalculatorTest.kt`, `OssHealthRepositoryTest.kt`.
+- **What:** Add the `oss_health` table (one row per `scm_repo`: raw score, four sub-scores, status enum, `computed_at`), its JPA `@Entity` + Spring Data JPA repository (with an HQL "find stalest / not-yet-computed" query), and the pure `OssHealthCalculator` implementing the §8 formula incl. zero-denominator handling. Ensure the new package is on the entity/repository scan path.
+- **Validation:** `./gradlew :core:scm-repository:test --tests "*OssHealthCalculatorTest" --tests "*OssHealthRepositoryTest"` — calculator pins the §8 worked example + every edge case; repository test (Testcontainers) exercises the migration and HQL round-trip via `BaseUnitWithDbLayerTest`.
+- **Depends on:** —
+
+## Milestone 2 — GitHub GraphQL activity fetch
+- **Files:** `integrations/github/.../GitHubIntegration.kt` (new method, e.g. `getRepositoryActivity(nativeId, since)`); `integrations/github/.../GitHubIntegrationKohsukeLibrary.kt`; `integrations/github/.../graphql/GitHubGraphQlClient.kt`; `integrations/github/.../GitHubRepositoryActivity.kt` (model); test `GitHubGraphQlActivityTest.kt`.
+- **What:** Add an OkHttp-based GraphQL client (POST to `api.github.com/graphql` with the existing PAT) and one integration method returning a `GitHubRepositoryActivity` model: paginated 12-week commit history (weekly buckets + per-author counts), issues (`createdAt`/`closedAt`), PRs (`createdAt`/`mergedAt`), and `isArchived`/`isDisabled`. Add a Micrometer counter consistent with existing request metrics.
+- **Validation:** `./gradlew :integrations:github:test --tests "*GitHubGraphQlActivityTest"` — drives the parser/pagination against recorded GraphQL JSON via `MockWebServer`; asserts the archived/disabled flags and the bucketed/aggregated fields.
+- **Depends on:** —
+
+## Milestone 3 — OSS Health computation job
+- **Files:** `app/.../job/{OssHealthUpdatingJob,OssHealthUpdatingService}.kt`; config in `app/src/main/resources/application.yml` + `application-local.yml` (tick interval, threshold, enabled toggle) + `application-test.yml` (toggle off); test `OssHealthUpdatingServiceTest.kt`.
+- **What:** `@Scheduled` job (rate from property, `@SchedulerLock("updateOssHealthLock")`) that picks the single stalest health record, fetches activity (M2), maps it to `RepositoryActivityInput`, sets `SKIPPED` for archived/disabled and `INSUFFICIENT_DATA` for repos < 12 weeks old, otherwise computes (M1) and persists; reuses the existing `BackoffProvider` and emits success/skipped/failed metrics + a pending-count gauge.
+- **Validation:** `./gradlew :app:test --tests "*OssHealthUpdatingServiceTest"` — mocks integration + repository + calculator; asserts archived→`SKIPPED`, too-new→`INSUFFICIENT_DATA`, success→`COMPUTED` persisted, and failure→backoff with the prior score retained.
+- **Depends on:** Milestone 1, Milestone 2
+
+## Milestone 4 — Expose `ossHealth` in search & project details
+- **Files:** `app/src/main/resources/db/migration/2026-Q2/2026-06-01_recreate_project_index_with_oss_health.{yml,sql}`; `core/search/.../{SearchProjectResult,SearchProjectResultDTO}.kt` + `ProjectSearchRepositoryJdbc.kt` (row mapper); `core/project/.../ProjectDetailsDTO.kt` (+ assembly site); display-threshold property wiring; OpenAPI annotations; tests `ProjectIndexOssHealthTest.kt` (DB-integration) + a `SmokeTestBase` case.
+- **What:** Recreate `project_index` joining `project → scm_repo → oss_health` to carry raw score + status; add the gated `ossHealth` field to both DTOs, applying the `< 40` cutoff at DTO assembly (numeric only when `>= 40`; `"insufficient"` for `<40`/`INSUFFICIENT_DATA`; absent/null for `SKIPPED`/no row).
+- **Validation:** `./gradlew :core:search:test --tests "*OssHealth*"` and `./gradlew :app:test --tests "*OssHealth*Smoke*"` — DB-integration asserts the view join surfaces the score (null for `SKIPPED`); smoke asserts the three JSON states are distinguishable in search + details responses.
+- **Depends on:** Milestone 1
+
+## Open questions carried from spec
+- **None** — all `[NEEDS CLARIFICATION]` markers were resolved in the spec.
+- Carry-forward notes (not blockers): (1) the JPA-in-a-JDBC-module divergence is a deliberate, user-requested choice flagged in §8 "Tension to confirm" — confirm entity scanning during M1. (2) §8 "Revisit if": validate the formula constants against a sample of real repos on `klibs-features` (the reviewer-only step in §11) before relying on the score distribution.
+</content>
+</invoke>

--- a/docs/specs/oss-health-metric/spec.md
+++ b/docs/specs/oss-health-metric/spec.md
@@ -1,0 +1,174 @@
+# Spec: OSS Health Metric
+
+**Input:** verbatim seed text — preserved for traceability
+
+> We need to implement OSS Health metric for project. Here is RFC, that contains a section describing this metric: `/Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for author-faced insights.md`. Do a thorough research on the mentioned papers and align the metric to the klibs.io usecase.
+
+## 1. Goal
+Compute and expose a per-project **OSS Health** score (0–100) — a composite, research-backed signal of repository activity and responsiveness — so that visitors of a klibs.io project page can judge whether a library is actively maintained without needing to skim GitHub themselves.
+
+## 2. Problem
+- klibs.io currently exposes only point-in-time GitHub fields per repository: `stars`, `open_issues`, `last_activity_ts`, `license`. None of these on their own tell a visitor whether a library is being actively maintained — a high-star library can be abandoned, a low-star one can be healthy.
+- The research the RFC cites ([Iqbal et al., 2023](https://arxiv.org/abs/2309.12120v3)) shows that single raw indicators (stars, commit recency, issue counts) do not reliably identify OSS sustainability. A composite is needed.
+- **Affected:** end users of klibs.io evaluating library trustworthiness; library maintainers who want a neutral, defensible signal of their project's activity surfaced on the platform.
+
+## 3. User scenarios & acceptance
+
+### Scenario 1 — Visitor sees health on a project page (P1)
+- **Given:** a project whose backing GitHub repo has at least 12 weeks of recorded activity and the OSS Health score has been computed.
+- **When:** the visitor opens the project details page (`/project/{ownerLogin}/{projectName}/details`).
+- **Then:** the response includes an `ossHealth` field with an integer 0–100, plus the timestamp at which it was last computed.
+- **Independent test:** seed `scm_repo` + the new snapshot/stats tables with a fixture worth of activity; call the details endpoint; assert `ossHealth` is present and within [0, 100].
+
+### Scenario 2 — Insufficient data is reported, not hidden silently (P1)
+- **Given:** a project whose backing repo has fewer than 12 weeks of recorded commit/issue/PR activity, OR for which the heavy weekly job has not yet succeeded.
+- **When:** the visitor opens the project details page.
+- **Then:** `ossHealth` is `null` (or carries an explicit "insufficient data" indicator — see FR-008) and a machine-readable reason is conveyed so the frontend can render *"Insufficient activity data"* rather than a misleading "0".
+- **Independent test:** seed a brand-new repo with one commit; assert the field is `null`/insufficient and not `0`.
+
+### Scenario 3 — Health updates on a predictable cadence (P1)
+- **Given:** a project that has had an OSS Health score computed.
+- **When:** the weekly recomputation job runs.
+- **Then:** the score is updated using the latest 12-week window of commit/issue/PR/contributor data, and the stored `computed_at` timestamp moves forward.
+- **Independent test:** run the job in a test harness with a stubbed `GitHubIntegration`; assert the score row is upserted with the new `computed_at`.
+
+### Scenario 4 — Rate-limit-aware refresh (P1)
+- **Given:** the heavy weekly job is running through a backlog of projects, each costing ~5–10 GitHub API calls.
+- **When:** the remaining GitHub rate-limit budget drops below a safe threshold.
+- **Then:** the job pauses/yields without failing the overall scheduled run, and resumes on the next iteration without dropping any project.
+- **Independent test:** unit test the job loop with a fake `GitHubIntegration.getRateLimitInfo()` that returns low remaining; assert the loop exits cleanly and the un-processed projects are still queued.
+
+### Edge cases
+- **Repo younger than 12 weeks:** report insufficient data. Do not extrapolate (per RFC's "negative impact risk" note — a misleadingly low score is worse than no score).
+- **Repo with zero issues / zero PRs over the window:** the Issue and PR sub-scores have undefined ratios. We treat the sub-component as `0` for the ratio term but **must not** zero out the entire `I` or `P` — see FR-009.
+- **Repo with one contributor:** `TopContributorCommitShare = 1.0`, so the diversity sub-score becomes `0.6 * (1/5) + 0.4 * 0 = 0.12`. This is intended; a one-person project legitimately scores low on diversity.
+- **Archived / disabled GitHub repo:** [NEEDS CLARIFICATION: do we skip computation for archived repos (and clear any existing score), or compute as normal so the score decays naturally?]
+- **GitHub returns 202 for `/stats/participation` or `/stats/contributors`** (stats not yet cached on GitHub's side): retry on the next weekly run; do not fail the job. The previously-computed score is retained until the next successful run.
+- **Repository renamed / transferred:** the `nativeId` (numeric repo ID) is stable across renames; snapshots and history must key on `nativeId`, not on `owner/name`.
+- **klibs egress NAT IP pool is shared** between `klibs-stage` and `klibs-features`; with ~5–10 calls per repo per week and N projects, the heavy job must stay within the shared GitHub PAT budget (5,000 req/hr authenticated) and yield well before exhaustion — see NFR-Rate-limits.
+
+## 4. Functional requirements
+
+- **FR-001:** System MUST compute an OSS Health score in `[0, 100]` per scm-repository, defined as `100 * (0.30*C + 0.25*I + 0.25*P + 0.20*A)`, where the four sub-scores `C, I, P, A ∈ [0, 1]` are computed per the formula below.
+- **FR-002:** System MUST compute `C` (Commit Consistency) over the last 12 weeks of weekly commit buckets from GitHub `GET /repos/{owner}/{repo}/stats/participation` as `C = max(0, 1 - CV / 0.6)` where `CV = stdev(weekly_commits) / mean(weekly_commits)`. If `mean == 0`, then `C = 0` (no commits = no consistency).
+- **FR-003:** System MUST compute `I` (Issue Responsiveness) as `I = 0.5 * min(1, IssueCloseRatio / 0.4) + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)`, where:
+    - `IssueCloseRatio = issues_closed_in_window / issues_opened_in_window` over the last 12 weeks, derived from the daily diff snapshots.
+    - `MedianIssueCloseDays` is computed by paginating issues closed within the last 12 weeks (`GET /repos/{owner}/{repo}/issues?state=closed&since=...`) and taking the median of `(closed_at - created_at)` in days.
+- **FR-004:** System MUST compute `P` (PR Management) as `P = 0.5 * min(1, PRMergeRatio / 0.5) + 0.5 * max(0, 1 - MedianPRMergeDays / 14)`, with `PRMergeRatio` and `MedianPRMergeDays` defined analogously to FR-003 but for PRs (`GET /repos/{owner}/{repo}/pulls?state=closed&since=...`, filtered to merged).
+- **FR-005:** System MUST compute `A` (Author Diversity) as `A = 0.6 * min(1, ActiveContributors / 5) + 0.4 * (1 - TopContributorCommitShare)`, using `GET /repos/{owner}/{repo}/stats/contributors`. `ActiveContributors` is the count of distinct contributors with at least one commit in the last 12 weeks; `TopContributorCommitShare = top_committer_commits / total_commits` in that window. If `total_commits == 0`, `TopContributorCommitShare = 0` and `ActiveContributors = 0` → `A = 0`.
+- **FR-006:** System MUST run a **daily diff snapshot** job that records, per `scm_repo`, `open_issues_total` (and PR equivalent if obtainable cheaply) so that `opened_delta` and `closed_delta` can be derived without paginating issues each day. This piggybacks on the existing 30-second `GitHubRepositoryUpdatingJob` and adds no extra GitHub calls.
+- **FR-007:** System MUST run a **weekly heavy job** that, per repo, calls `/stats/participation`, `/stats/contributors`, and paginates closed issues + closed PRs since `now - 12 weeks` to compute medians; then computes the final OSS Health score and upserts it. ShedLock name: `computeOssHealthLock`. Cadence: [NEEDS CLARIFICATION: exact weekly cron — e.g., Sundays 03:00 UTC, or staggered to avoid clashing with the daily 02:00 Maven indexing job mentioned in CLAUDE.md].
+- **FR-008:** System MUST distinguish "score not yet computed" / "insufficient data" from "score is 0". The persisted shape is `(score INT NULL, computed_at TIMESTAMP NULL, status ENUM: OK | INSUFFICIENT_DATA | STALE)`. The API field is nullable; the response also carries a status enum.
+- **FR-009:** System MUST treat *missing* sub-component inputs distinctly from *zero* sub-component inputs. Specifically: if a repo has zero issues opened in the window, its `IssueCloseRatio` ratio term contributes `0` (the project simply didn't get any issues to respond to), but the median term contributes its full `1.0` weight (there were no slow closes either). Same for PRs. The RFC's formula already accommodates this via the `min(1, …)` / `max(0, …)` clamps; this requirement just makes the intent explicit.
+- **FR-010:** System MUST require **at least 12 weeks** of `scm_repo` history (since `created_at`) before computing a score. Repos younger than 12 weeks are marked `INSUFFICIENT_DATA`.
+- **FR-011:** System MUST expose `ossHealth` (nullable integer) and `ossHealthStatus` (enum) on `ProjectDetailsDTO`. [NEEDS CLARIFICATION: do we also expose `ossHealth` in the search results DTO (`SearchProjectResult`) — i.e., on the `project_index` materialized view — for ranking or display, or only on the details endpoint?]
+- **FR-012:** System MUST be controllable via a `klibs.*` feature toggle so the heavy weekly job can be disabled in `local` / `prod` independently (mirroring the existing `klibs.indexing` toggle pattern).
+- **FR-013:** System MUST NOT compute or display an OSS Health score for archived or disabled GitHub repositories — pending FR-edge-case clarification above. [NEEDS CLARIFICATION: confirm.]
+- **FR-014:** System MUST NOT change the weights / thresholds from the RFC formula without an explicit spec amendment — they are deliberately frozen to the RFC's simplified CSI variant. (See §8 Option A vs B.)
+
+## 5. Non-functional requirements
+
+- **Performance:** Score computation is offline (job-driven), not request-time. The API read path (`/project/.../details`) MUST add no more than a single indexed lookup on the score table (or a join on `scm_repo_id`). No GitHub API call on the read path.
+- **External rate limits:**
+    - GitHub: heavy job costs ~5 calls per repo (`/stats/participation` + `/stats/contributors` + ≥1 page of closed issues + ≥1 page of closed PRs + occasional retry on 202). With ~5,000/hr authenticated budget and the klibs-stage / klibs-features shared NAT pool (see `[[reference_klibs_egress_ips]]`), the job must process repos serially with rate-limit checks, not in parallel bursts.
+    - The job MUST check `GitHubIntegration.getRateLimitInfo()` before each repo and yield if `remaining < safetyMargin` (margin TBD; recommend ≥ 200 to leave headroom for the existing 30-second `GitHubRepositoryUpdatingJob` running concurrently).
+- **Concurrency:** New ShedLock keys: `computeOssHealthLock` (weekly heavy job) and — if we add a separate daily diff snapshot job rather than piggybacking — `snapshotScmRepoMetricsLock`. The heavy job and existing `updateGitHubRepositoryLock` job both call GitHub; they share the same egress IP / PAT and therefore the same rate-limit pool — see above.
+- **Observability:**
+    - Micrometer counter for each new GitHub call type (`stats_participation`, `stats_contributors`, `issues_paginated`, `pulls_paginated`), consistent with the existing per-request-type counters in `GitHubIntegrationKohsukeLibrary`.
+    - Counter / gauge for `oss_health_compute_success_total`, `oss_health_compute_failure_total{reason}`, `oss_health_insufficient_data_total`.
+    - Log line per repo at INFO with the four sub-scores so we can debug a surprising final number without re-running.
+- **Security:** Read-only endpoint addition (no auth boundary change). The score is non-sensitive aggregate metadata. No personal data is persisted beyond the *count* of contributors (no logins stored in the snapshot table).
+
+## 6. Out of scope
+
+- Author-facing analytics (the P3 items in the RFC: page views, snippet copies, outbound clicks, search impressions/clicks). Those depend on the GitHub OAuth flow described in the RFC's "Authentication" section — separate spec.
+- Number-of-dependents (P1 in the RFC) — already in the codebase (`project.dependent_count`). Not part of this spec.
+- Maven downloads, pub.dev–style Likes/Points, trending. Not in this spec.
+- Triangular-membership / fuzzy normalization from the original CSI paper (arXiv 2504.00542). We deliberately use the RFC's simplified linear-with-clamps form — see §8.
+- Repository-centrality network analysis (arXiv 2405.07508). Explicitly rejected by the RFC as "too much computation for klibs purposes."
+- Showing a numeric score below a display cutoff (the RFC suggests "show only if ≥ 40, else *Insufficient activity data*"). The **backend always returns the score**; the **display cutoff is a frontend concern**, except that we expose the `status` enum (FR-008) so the frontend can implement the rule trivially.
+- Backfilling historical commit / issue / PR data older than what GitHub returns in a single call window. We start the window at `now`; the first 12 weeks after rollout will yield `INSUFFICIENT_DATA` for the issue-delta-derived ratio terms unless we explicitly backfill — see §11 assumption.
+
+## 7. Klibs.io technical surface
+
+- **Modules touched:**
+    - `core/scm-repository` — new sub-entity / table for the OSS Health score and the daily delta snapshot; possibly a new sub-package `oss-health` to keep concerns isolated (or a sibling module `core/oss-health` — see §8 Option B vs C).
+    - `integrations/github` — new methods on `GitHubIntegration`: `getWeeklyCommitParticipation(repositoryId)`, `getContributorStats(repositoryId)`, `listClosedIssuesSince(repositoryId, since)`, `listClosedPullRequestsSince(repositoryId, since)`. New per-request micrometer counters. Possibly a `BusyException`-equivalent for 202 responses.
+    - `app` — new scheduled job(s); new Liquibase migration; wiring in `ProjectDetailsService` (or wherever `ProjectDetailsDTO` is assembled) to read the score.
+    - `core/project` — additive change to `ProjectDetailsDTO`.
+- **Database:**
+    - New table `scm_repo_metrics_daily` (or similar): `scm_repo_id INT PK part`, `snapshot_date DATE PK part`, `open_issues_total INT`, `[NEEDS CLARIFICATION: do we want open_prs_total here too — GHRepository.openIssueCount lumps issues + PRs together, so we'd need a cheap separate read, or accept lumping]`, retention policy TBD (recommend 90 days rolling).
+    - New table `oss_health_score`: `scm_repo_id INT PK`, `score INT NULL`, `status VARCHAR/ENUM`, `c_component NUMERIC`, `i_component NUMERIC`, `p_component NUMERIC`, `a_component NUMERIC`, `computed_at TIMESTAMP NULL`. Storing the sub-components alongside the final score makes both debugging and a future "why is my score X?" author breakdown trivial.
+    - Migration folder: `app/src/main/resources/db/migration/2026-Q2/` (current quarter per the survey).
+    - Additive-only: yes. No backfill of historical data; FR-010 covers the cold-start period.
+- **Persistence style:** `scm-repository` currently mixes JPA entities and raw SQL. Match the existing style of `ScmRepositoryRepository` for the new sub-entity. [NEEDS CLARIFICATION: confirm whether the maintainer prefers JPA or raw JDBC for the new score/snapshot tables — both are present in the module.]
+- **Search / materialized views:**
+    - `project_index` will need a new column `oss_health` and the view's `CREATE OR REPLACE MATERIALIZED VIEW` SQL updated **only if** FR-011 clarification lands on "expose in search results." Otherwise the score lives in a side table joined at details-fetch time only.
+    - `package_index` is unaffected (per-package, not per-project).
+- **External integrations:**
+    - GitHub REST API endpoints added: `GET /repos/{owner}/{repo}/stats/participation`, `GET /repos/{owner}/{repo}/stats/contributors`, paginated `GET /repos/{owner}/{repo}/issues?state=closed&since=…`, paginated `GET /repos/{owner}/{repo}/pulls?state=closed&since=…`.
+    - GitHub may return `HTTP 202 Accepted` from the `/stats/*` endpoints on first access while it generates the stats; the integration MUST treat 202 as "retry next week," not as an error.
+    - Retry / backoff: piggyback on whatever the existing kohsuke wrapper does for transient errors. No new backoff scheme.
+- **Scheduled jobs:**
+    - New `OssHealthComputeJob` (`@Scheduled` weekly, e.g. `cron = "0 0 3 * * SUN"`); ShedLock name `computeOssHealthLock`. Iterates over `scm_repo` rows where `oss_health_score.computed_at IS NULL OR < now() - 7 days`.
+    - Either extend `GitHubRepositoryUpdatingJob` to also write a row into `scm_repo_metrics_daily` (preferred — no extra API calls), or add a tiny daily job that walks `scm_repo` and writes snapshots from the *already-stored* `open_issues` value. Either way, **no new GitHub calls per day**.
+    - Idempotency: both jobs upsert keyed by `(scm_repo_id, snapshot_date)` / `scm_repo_id`. Re-running the weekly job for the same repo on the same day MUST yield the same score (i.e., must not double-count anything).
+- **Storage:** No S3 / no local cache impact. README handling is untouched.
+- **Configuration:** New `klibs.oss-health.*` properties — `enabled: Boolean = true`, `weekly-cron: String = "0 0 3 * * SUN"`, `repos-per-iteration: Int = N`, `rate-limit-safety-margin: Int = 200`. Profile defaults: enabled in `local` and `prod`; disabled in `test` (see `[[feedback_property_toggles_over_profile]]`).
+- **API surface:** Additive change to `ProjectDetailsDTO`: new nullable `ossHealth: Int?` and `ossHealthStatus: String` (or enum). OpenAPI doc auto-regenerates. **Not** a breaking change.
+- **Frontend contract:** `klibs-frontend` needs to:
+    1. Render the new field, with the RFC's "show only if ≥ 40, else *Insufficient activity data*" rule applied client-side.
+    2. Optionally render a tooltip explaining the four sub-scores (the breakdown is stored server-side per FR-table-design, so a future `/oss-health/{projectId}/breakdown` endpoint is cheap to add — out of scope for v1).
+
+## 8. Design options considered
+
+### Option A — Paper-faithful CSI (triangular membership functions)
+Use the original CSI paper's normalization: each sub-component is normalized via a triangular function with the paper's target values (`μ_c = 0.25, σ_c = 0.25`, etc.) and the paper's stability thresholds (CSI ≥ 0.7 = stable).
+
+- **Pros:** Defensible against academic critique; the paper's authors picked those constants for a reason.
+- **Cons:** The paper itself is "conceptual" and "open to debate"; empirical validation is acknowledged-pending. Triangular membership functions are non-monotonic — a repo can score *worse* by getting *more* commits than the target, which is counterintuitive for authors and harder to explain.
+
+### Option B — RFC's simplified linear-with-clamps form (recommended)
+Use the formula in the RFC verbatim: linear normalization clamped by `min(1, x / threshold)` for "more is better" terms and `max(0, 1 - y / threshold)` for "less is better" terms. Always monotonic.
+
+- **Pros:** Monotonic and explainable — "more closed issues is always better, up to the cap"; the RFC's thresholds (`IssueCloseRatio / 0.4`, `MedianIssueCloseDays / 21`, `PRMergeRatio / 0.5`, `MedianPRMergeDays / 14`, `ActiveContributors / 5`) are concrete and reviewable. Simpler to implement and to defend to an author who asks "why did my score drop?"
+- **Cons:** Less "faithful" to the source paper; thresholds are picked by the RFC author, not from a published study. (Mitigation: the [Iqbal et al. paper](https://arxiv.org/abs/2309.12120v3) the RFC cites supports the *idea* of a composite over single signals but does not prescribe specific constants — so any choice is a judgment call.)
+
+### Option C — Recompute on-demand from raw GitHub (no persistence)
+Cache nothing; compute on first request per project per week and cache in-process.
+
+- **Pros:** Minimal schema change; trivially correct.
+- **Cons:** Hot path now depends on GitHub availability; shared NAT IP rate limits make this fragile under traffic; defeats the entire premise of a precomputed score.
+
+**Decision:** **Option B**. Rationale: matches the RFC author's intent; monotonic and explainable; thresholds are reviewable in this spec rather than buried in a paper's appendix. Option A can be revisited if Option B's scores prove poorly calibrated against a hand-labeled sample of known-healthy / known-abandoned repos — but that's empirical follow-up work, not a v1 concern.
+
+## 9. Key entities
+
+- **OssHealthScore:** one row per `scm_repo`. Stores the final integer score, the four sub-components (`c, i, p, a` as numeric for debugging), a status enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`), and a `computed_at` timestamp. Lifecycle: created lazily on first successful weekly run for a repo; updated weekly; deleted only if the parent `scm_repo` is deleted (cascade).
+- **ScmRepoMetricsDailySnapshot:** rolling daily snapshot of fields needed for issue/PR ratio derivation. Composite PK `(scm_repo_id, snapshot_date)`. Lifecycle: appended once per repo per day by the existing 30s job (or a thin new daily job); pruned to the last ~90 days (12 weeks + headroom).
+
+## 10. Test strategy
+
+- **Unit:**
+    - `OssHealthCalculator` (pure function from `(weeklyCommits, openedClosedIssueCounts, medianIssueDays, openedClosedPrCounts, medianPrDays, activeContributors, topShare) -> Int score + components`). Test the formula edge cases: zero commits (C=0), zero issues, zero PRs, single contributor, perfectly balanced repo. Cover the FR-009 "missing vs zero" semantics with explicit cases.
+    - Job loop unit test (with mocked `GitHubIntegration`) that verifies rate-limit yield (Scenario 4) and that 202 responses cause the repo to be skipped without state change.
+- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses for the new score/snapshot repositories. Method-level `@Sql` seeds per `[[feedback_sql_seed_method_level]]`. Verify upsert idempotency.
+- **Web / smoke:** `SmokeTestBase` test that hits `/project/.../details` against a seeded fixture and asserts the new fields appear in the JSON response with the expected shape, including the null case (FR-008) and a populated case.
+- *Reviewer-only — manual / staging:* deploy to `klibs-features` (per `[[feedback_never_prod_unprompted]]`), run the weekly job manually with `repos-per-iteration` set low, watch the new counters in the actuator output, spot-check 3–5 known repos (one obviously healthy, one obviously abandoned, one new) and confirm the scores feel directionally right. Compare against rate-limit headroom on the shared NAT IP pool.
+
+## 11. Assumptions
+
+- The RFC's "Heavy weekly job (5-10 API calls per repo)" is a soft upper bound; for repos with many closed issues/PRs the pagination cost grows. We assume a `Link: next` cap of ~3 pages (300 items) per endpoint is sufficient to compute medians representative of the 12-week window. If a repo has more than 300 closed issues in 12 weeks, the median over the first 300 is a fine approximation.
+- The first 12 weeks after rollout will have only forward-going daily delta data, so the `IssueCloseRatio` and `PRMergeRatio` terms will only be reliable for windows starting at deploy time. We accept that the **first ~3 months post-deploy** is a warmup during which many repos report `INSUFFICIENT_DATA`. Alternative — backfilling via `GET /issues?state=closed&since=12wk_ago` for every repo at deploy time — is feasible but expensive; we defer that decision (see §6 out-of-scope).
+- The `GitHubRepositoryUpdatingJob`'s 30-second cadence (3 repos per run = ~360 repos/hour) is comfortably faster than the weekly cadence of the heavy job, so the daily-diff piggyback in FR-006 will populate `scm_repo_metrics_daily` for every repo within ~hours. We assume the heavy job runs *after* enough daily snapshots exist (≥ 84 days of snapshots) — for the first 12 weeks post-rollout, repos will be `INSUFFICIENT_DATA`.
+- Display semantics (`>= 40 ⇒ show number`, `< 40 ⇒ show "Insufficient activity data"`) are a frontend concern. The backend always returns the raw number when computable; the `status` enum is the contract. This separation lets us tune the display cutoff later without re-deploying the backend.
+- The numeric `nativeId` of a GitHub repo is stable across renames/transfers (this is GitHub's documented behavior); we key all new tables off `scm_repo.id`, which already keys off `nativeId`.
+
+## 12. References
+
+- RFC, source of truth for this spec: `/Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for author-faced insights.md`.
+- *Introducing Repository Stability* — arXiv [2504.00542](https://arxiv.org/abs/2504.00542) (2025). Source of the CSI formula structure (weights 0.30 / 0.25 / 0.25 / 0.20). Paper acknowledges its "conceptual phase" status; we adopt the four-dimension structure but **not** its triangular-membership normalization (see §8).
+- *Individual context-free online community health indicators fail to identify open source software sustainability* — arXiv [2309.12120v3](https://arxiv.org/abs/2309.12120v3) (2023, rev. 2024). Motivates the composite-over-single-metric choice; cited in problem statement.
+- *Revealing the value of Repository Centrality in lifespan prediction of OSS Projects* — arXiv [2405.07508](https://arxiv.org/abs/2405.07508) (2024). Explicitly out of scope per the RFC (too compute-heavy).
+- Existing klibs.io entities referenced: `ScmRepositoryEntity` (`core/scm-repository`), `ProjectDetailsDTO` (`core/project`), `GitHubIntegration` (`integrations/github`), `project_index` materialized view (`core/search`).
+- Memory: `[[reference_klibs_egress_ips]]` (shared NAT pool — rate-limit budget is per-IP, not per-replica), `[[reference_ghratelimit_record_ctor]]` (kohsuke ctor-order gotcha), `[[feedback_property_toggles_over_profile]]`, `[[feedback_sql_seed_method_level]]`, `[[feedback_ask_before_additive_migration]]`.

--- a/docs/specs/oss-health-metric/spec.md
+++ b/docs/specs/oss-health-metric/spec.md
@@ -15,7 +15,7 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
 ### Scenario 1 — Actively maintained repo gets a health score (P1)
 - **Given:** a non-archived GitHub repository with regular commits, issues, and merged PRs over the last 12 weeks.
 - **When:** the OSS Health computation runs for that repository.
-- **Then:** a numeric score in `[0,100]` is computed and persisted with status `COMPUTED`, and the value is returned in the project's search-result payload and project-details payload.
+- **Then:** a numeric score in `[0,100]` is computed and persisted with status `COMPUTED`; because it is `>= 40` it is returned as a numeric value in the project's search-result payload and project-details payload.
 - **Independent test:** seed an `scm_repo` + `project` and a fixture of activity inputs; run the computation; assert via JPA/HQL that a health row exists with status `COMPUTED` and the score matches the formula (§8) for those inputs.
 
 ### Scenario 2 — Archived / disabled repo is skipped (P1)
@@ -25,15 +25,15 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
 - **Independent test:** mark the repo archived in the GraphQL fixture; run the computation; assert via HQL the status is `SKIPPED` and the API response field is null.
 
 ### Scenario 3 — Low-activity repo is computed but flagged insufficient (P2)
-- **Given:** a repository with activity below the display threshold (computed score `< 40`, or too little data to compute a meaningful score, e.g. fewer than `[NEEDS CLARIFICATION: minimum weeks of history / minimum commit count to consider data sufficient]`).
+- **Given:** a repository that is either computed but below the display threshold (score `< 40` — including quiet repos whose zero-denominator dimensions scored 0), or too new to score because it lacks a full 12-week window (`INSUFFICIENT_DATA`, per §8).
 - **When:** the computation runs.
-- **Then:** the API distinguishes three states for the consumer — *not yet computed*, *computed but below the display threshold / insufficient data*, and *computed and displayable* — so the frontend can render "Insufficient activity data" without confusing it with a genuine score of 0.
-- **Independent test:** seed sparse activity; assert the response carries a status/flag distinguishing "insufficient" from a real low score and from "not yet computed".
+- **Then:** the API exposes only the **"insufficient"** indicator for this repo — no numeric score — so the frontend renders "Insufficient activity data"; the raw sub-40 value is never sent.
+- **Independent test:** seed sparse activity (resulting score `< 40`, or a repo younger than 12 weeks); assert the response carries the "insufficient" indicator and **no** numeric `ossHealth` value.
 
 ### Edge cases
-- **Zero commits in the 12-week window** → coefficient of variation is undefined (mean = 0). Treated as insufficient data, not score 0.
-- **Zero issues opened in the window** → issue close ratio `closed/opened` is undefined; the issue dimension contribution must be defined for this case (see §8).
-- **Zero PRs in the window** → same for the PR dimension.
+- **Zero commits in the 12-week window** → CV undefined (mean = 0) → `C = 0` and `A = 0`; the repo is still scored (composite reflects any issue/PR activity).
+- **Zero issues opened in the window** → issue close ratio `closed/opened` undefined → `I = 0`; the repo is still scored, per §8.
+- **Zero PRs opened in the window** → PR merge ratio undefined → `P = 0`; the repo is still scored, per §8.
 - **Single contributor** → top-contributor commit share = 1, so the diversity sub-term contribution is 0; this is a valid low (not an error).
 - **Repository younger than the 12-week window** → partial window; treated as insufficient data.
 - **GraphQL call fails / times out for a repo** → the previously persisted score (if any) is retained, the repo is backed off and retried later; one failure does not zero out the score.
@@ -41,18 +41,18 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
 
 ## 4. Functional requirements
 
-- **FR-001:** System MUST expose an `ossHealth` field on the **project search-results payload** and on the **project-details payload**, carrying the computed OSS Health score as an integer in `[0,100]`.
-- **FR-002:** The API MUST distinguish "not yet computed" from a computed score, and MUST NOT report a computed score of `0` as equivalent to "no data". (A consumer reading the response can tell the difference.)
-- **FR-003:** System MUST NOT compute or report an OSS Health score for an archived or disabled repository; `ossHealth` for such a project MUST be null/absent rather than `0`.
+- **FR-001:** System MUST expose an `ossHealth` field on the **project search-results payload** and on the **project-details payload**, carrying the OSS Health score as an integer when displayable (see FR-002/FR-005).
+- **FR-002:** The `ossHealth` field MUST communicate exactly one of three consumer-visible states: a **numeric score** (`>= 40`), an **"insufficient"** indicator, or **absent/null** (nothing to show). All three MUST be distinguishable by the consumer. (The exact JSON encoding is a plan-level detail; the contract is that the three states are distinguishable.)
+- **FR-003:** System MUST NOT compute or report an OSS Health score for an archived or disabled repository; `ossHealth` for such a project MUST be the **absent/null** state of FR-002 — never `0` and never the "insufficient" indicator.
 - **FR-004:** The OSS Health score MUST be computed according to the formula and input windows defined in §8 (Decision — OSS Health formula). Given a fixed set of activity inputs, the resulting score MUST be deterministic and reproducible.
-- **FR-005:** The API MUST allow the consumer to distinguish a *displayable* score from a *below-threshold / insufficient-data* score, so the frontend can apply the product display rule (hide / show "Insufficient activity data") without inventing its own cutoff. `[NEEDS CLARIFICATION: does the backend gate display at score < 40 by returning a status, or return the raw score plus an "insufficient" flag and let the frontend apply the 40 cutoff?]`
+- **FR-005:** The backend MUST apply the display cutoff itself: when a computed score is `< 40`, or the repository is too new to score (`INSUFFICIENT_DATA`), the API MUST expose only the **"insufficient"** indicator and MUST NOT include the raw numeric value. The numeric `ossHealth` value MUST be present **only** when the score is `>= 40`. The frontend never receives a sub-40 number and applies no cutoff of its own.
 - **FR-006:** OSS Health scores MUST be refreshed over time so the value reflects recent activity; a stale score MUST eventually be recomputed without manual intervention.
 
 ## 5. Non-functional requirements
 
-- **External rate limits — GitHub GraphQL:** The GitHub GraphQL API is metered by a **point budget of 5000 points/hour per authenticated token** (point-based, *not* per-IP). klibs.io uses a single personal access token (`klibs.integration.github.personal-access-token`), so this budget is shared across all replicas and across the existing REST jobs that use the same token — independent of the shared Cloud NAT egress IPs. The OSS Health job MUST stay within this budget alongside existing GitHub traffic.
+- **External rate limits — GitHub GraphQL:** The GitHub GraphQL API is metered by a **point budget of 5000 points/hour per authenticated token** (point-based, *not* per-IP). klibs.io uses a single personal access token (`klibs.integration.github.personal-access-token`), so this budget is shared across all replicas — independent of the shared Cloud NAT egress IPs. GraphQL's point budget is **separate** from the REST request budget the existing kohsuke jobs consume, so this job does not eat into their allowance. At the weekly cadence (~3800 repos → ~24 repos/hour), even at tens of GraphQL points per repo the job uses a small fraction of the 5000 pts/hour budget.
 - **Concurrency / scheduling:** Computation MUST be spread across time — **one repository per scheduled tick** — rather than processing all repositories in a single heavy batch. The job MUST hold a distinct ShedLock lock so only one instance runs at a time. Per-repo failures MUST back off and retry (reuse the existing backoff pattern) without blocking other repos.
-- **Performance / staleness:** Each repository's score should be refreshed on roughly a **weekly** cadence. With one repo per tick, the tick interval is derived from the repository count and the target refresh window. `[NEEDS CLARIFICATION: current count of active (non-archived) repositories and the acceptable maximum staleness, to size the tick interval]`
+- **Performance / staleness:** ~**3800** repositories. Target a **weekly** full-corpus refresh. At one repo per tick, a complete weekly sweep needs a tick every `604800 s / 3800 ≈ 160 s` — i.e. **one repo every ~2.5–3 minutes** sweeps the whole corpus in ~7–8 days. The tick interval is a configurable `klibs.*` property defaulting to that range. No tighter staleness target is known; weekly is adequate because the inputs are 12-week aggregates that move slowly. Revisit if the repo count grows materially.
 - **Observability:** Add a Micrometer counter/timer for OSS Health computations (success / skipped / failed) and a gauge for the count of repos pending (re)computation, consistent with the existing GitHub-integration metrics.
 
 ## 6. Out of scope
@@ -77,7 +77,7 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
 - **Search / materialized views:** `project_index` must be recreated to add the `ossHealth` column (join `project → scm_repo → oss health`), following the existing recreate-view-with-new-column migration pattern (e.g. the `dependent_count` recreation). `package_index` unaffected.
 - **External integrations:** GitHub **GraphQL** (`https://api.github.com/graphql`) for commit history (weekly buckets + per-author counts), issues (created/closed timestamps), and PRs (created/merged timestamps). Existing REST `/stats/participation` and `/stats/contributors` are intentionally **not** used (they return 202 while GitHub computes stats asynchronously, which is unreliable for an on-demand job). Per-repo backoff/retry.
 - **Scheduled jobs:** New `@Scheduled` job in `app`, one repository per tick, distinct `@SchedulerLock` name (e.g. `updateOssHealthLock`), selecting the stalest health record (analogous to `findMultipleForUpdate`). Idempotent: recomputing yields the same score for the same inputs.
-- **Configuration:** New `klibs.*` properties for the job cadence and (optionally) the display threshold; default the job **on** but make it disableable via a property toggle (so it can be suppressed in tests/environments). No profile gating.
+- **Configuration:** New `klibs.*` properties: the job tick interval (default ~2.5–3 min, sized for a weekly sweep of ~3800 repos), the display threshold (default `40`), and an on/off toggle (default **on**, overridable to suppress the job in tests/environments). No profile gating.
 - **API surface:** Additive field `ossHealth` on the search-results and project-details responses; update OpenAPI docs. Additive only — not a breaking change.
 - **Frontend contract:** `klibs-frontend` will need to read `ossHealth` and the displayable/insufficient state, and render "Insufficient activity data" below the threshold. Out of scope here but the contract (FR-001, FR-005) is the dependency.
 
@@ -93,7 +93,7 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
   #   CV = stddev / mean of the 12 weekly commit counts   (population CV; RFC's "mean/std" is a typo)
   C = max(0, 1 - CV / 0.6)
 
-  # I — Issue responsiveness (window: see clarification below)
+  # I — Issue responsiveness (12-week window)
   IssueCloseRatio   = issuesClosedInWindow / issuesOpenedInWindow
   MedianIssueCloseDays = median close time of issues closed in window
   I = 0.5 * min(1, IssueCloseRatio / 0.4)
@@ -110,6 +110,12 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
   TopContributorCommitShare = top author's commits / total commits in window
   A = 0.6 * min(1, ActiveContributors / 5)
     + 0.4 * (1 - TopContributorCommitShare)
+
+  # Zero-denominator handling (all over the 12-week window):
+  #   issuesOpenedInWindow == 0  -> I = 0
+  #   prsOpenedInWindow    == 0  -> P = 0
+  #   commitsInWindow      == 0  -> C = 0 and A = 0   (CV undefined)
+  #   repo younger than 12 weeks -> not scored; status = INSUFFICIENT_DATA
   ```
 - **Why:** The paper's bell-shaped normalization would penalise very active projects (e.g. a high commit rate scores *lower*), which is counter-intuitive and demoralising for an author-facing signal — contrary to the RFC anti-goal "don't make authors feel bad". Monotonic-capped terms are easier to explain and defend. Weights `[0.30, 0.25, 0.25, 0.20]` are taken unchanged from the paper. Using a composite (rather than any single raw metric) is itself supported by arXiv 2309.12120, which finds single context-free indicators insufficient for sustainability judgments.
 - **Rejected:**
@@ -117,7 +123,9 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
   - *Repository-centrality / network-lifespan model* (arXiv 2405.07508) — requires building a cross-repo user–repository graph; far too much computation for klibs.io's per-repo budget.
   - *Single raw metric* (stars / last-commit / issue count alone) — rejected on the evidence of arXiv 2309.12120.
 - **Revisit if:** authors report the score feels unfair, or the chosen target constants (0.6, 0.4, 21d, 0.5, 14d, 5, etc.) produce poorly-distributed scores on real data — these constants should be validated against a sample of indexed repos before launch.
-- **Open:** `[NEEDS CLARIFICATION: the window for issue/PR opened/closed ratios and medians — the commit terms use 12 weeks; do the issue/PR ratios use the same 12 weeks, the RFC's per-day deltas, or a longer window such as 90 days?]` and the zero-denominator handling: `[NEEDS CLARIFICATION: when issuesOpenedInWindow == 0 (or prsOpenedInWindow == 0), is that dimension scored 0, omitted with weights renormalised, or treated as insufficient data?]`
+- **Resolved — window:** a single **12-week** window applies to all four dimensions (commit, issue, PR, author).
+- **Resolved — zero denominators:** an undefined sub-term caused by a zero denominator contributes **0** to its dimension; the repository is still `COMPUTED`. Specifically: `issuesOpenedInWindow == 0` → `I = 0`; `prsOpenedInWindow == 0` → `P = 0`; `commitsInWindow == 0` (CV undefined) → `C = 0` **and** `A = 0`. **Consequence:** a stable / "finished" library with little or no recent activity earns a genuine *low* composite score, which the `< 40` display gate (FR-005) then renders as "Insufficient activity data" — matching the RFC's display rule, rather than a separate status.
+- **Resolved — `INSUFFICIENT_DATA` status:** reserved for repositories too new to have a full 12-week window; these are not scored. (Archived/disabled repos → `SKIPPED`; a repo with no row yet → "not computed".)
 
 ### Decision — Compute all inputs from GitHub GraphQL, not REST stats or daily snapshots
 - **Choice:** Fetch every input via the GitHub GraphQL API: commit history over 12 weeks (yields both weekly buckets for C *and* per-author commit counts for A in one traversal), `issues` with `createdAt`/`closedAt`, and `pullRequests` with `createdAt`/`mergedAt`. Read `isArchived`/`isDisabled` from the same GraphQL repository query to drive the skip decision.
@@ -136,17 +144,25 @@ Compute a single, research-backed **OSS Health** score (0–100) per project fro
 - **Rejected:** Raw JDBC (`ScmRepositoryRepositoryJdbc` style) — matches the module's existing pattern but the user explicitly preferred JPA/HQL here; storing only the composite score (no sub-scores) — loses explainability and makes the formula untestable component-by-component.
 - **Tension to confirm:** CLAUDE.md says "match the existing persistence pattern in the touched module" (JDBC). Using JPA here is a deliberate, user-requested divergence — flag for reviewer.
 
+### Decision — Apply the `< 40` display gate at the response-mapping layer
+- **Choice:** Persist (and store in `project_index`) the **raw** computed score in `[0,100]`; apply the `< 40` cutoff when building the response DTOs — below threshold, emit the "insufficient" indicator and omit the number. The threshold is a config property (`klibs.*`, default `40`).
+- **Why:** Keeps the raw score available for debugging, metrics, and threshold tuning without re-running the materialized view; the cutoff is a presentation rule that can change without a migration. Satisfies FR-005 (the raw sub-40 value never crosses the API boundary).
+- **Rejected:** Storing the already-gated value in the view/DB — would bake the threshold into a migration and lose the raw score for analysis.
+
 ### Decision — Rolling one-repo-per-tick scheduled job with backoff
 - **Choice:** A new `@Scheduled` job that picks the single stalest health record each tick, computes its score, persists it, and applies the existing exponential backoff on failure. Distinct ShedLock lock `updateOssHealthLock`.
 - **Why:** Mirrors the proven `GitHubRepositoryUpdatingJob` pattern (`findMultipleForUpdate` + `BackoffProvider`), spreads GraphQL point usage smoothly across the hour/week (user-requested), and keeps the heavy work off any single tick.
-- **Rejected:** One heavy weekly batch over all repos — spikes the GraphQL budget and risks long lock-holds / partial failures.
+- **Rejected:**
+  - *One heavy weekly batch over all repos* — spikes the GraphQL budget and risks long lock-holds / partial failures.
+  - *Folding the computation into the existing `GitHubRepositoryUpdatingJob`* — that job runs every 30s, processes 3 repos/tick, hits cheap REST (kohsuke), and refreshes repo metadata far more often than health needs. Reusing its cadence would massively overshoot both the ~weekly health cadence and the 5000 pts/hr GraphQL budget; suppressing that with an inline "is health stale?" gate would couple two concerns with different selection orderings (stalest *metadata* row ≠ stalest *health* row), different rate-limit budgets (REST token vs GraphQL points), and different failure modes (a GraphQL secondary-limit shouldn't back off cheap metadata refresh, and vice versa). A separate job keeps failure isolation and budgeting clean and matches the existing one-job-per-concern layout (owner-update job, materialized-view job).
+- **Revisit if:** the health computation turns out to need only a cheap, single call per repo after all — then piggybacking on the existing visit becomes attractive.
 
 ## 9. Key entities
 
 - **`OssHealthEntity`** (working name): one row per `scm_repo`.
   - **Key fields:** `scmRepoId` (FK / identity to `scm_repo`), `score` (0–100, nullable when not displayable), `commitConsistency`, `issueResponsiveness`, `prManagement`, `authorDiversity` (the four component sub-scores in `[0,1]`), `status` (`COMPUTED` / `INSUFFICIENT_DATA` / `SKIPPED`), `computedAt` (Instant; JVMs run UTC, map Instant ↔ TIMESTAMP accordingly).
   - **Relationships:** one-to-one with `ScmRepositoryEntity`; surfaced per `project` via `project.scm_repo_id`.
-  - **Lifecycle:** created/updated by the rolling job; absence of a row = "not yet computed"; `SKIPPED` for archived/disabled repos; recomputed on the weekly cadence.
+  - **Lifecycle:** created/updated by the rolling job; absence of a row = "not yet computed"; `SKIPPED` for archived/disabled repos; `INSUFFICIENT_DATA` for repos too new for a full 12-week window; `COMPUTED` otherwise (zero-denominator dimensions score 0); recomputed on the weekly cadence.
 
 ## 10. Database schema diagram
 
@@ -161,7 +177,7 @@ erDiagram
         string license_name
     }
     OSS_HEALTH {
-        int scm_repo_id PK_FK "(new)"
+        int scm_repo_id PK,FK "(new)"
         int score "(new) nullable"
         float commit_consistency "(new)"
         float issue_responsiveness "(new)"
@@ -190,7 +206,7 @@ erDiagram
 - The single existing GitHub PAT has GraphQL access and sufficient point budget to add a weekly-per-repo health pass on top of current REST traffic.
 - The RFC's chosen simplified formula (and its weights/constants) is the intended contract; the paper-exact CSI is reference only.
 - "Spread across time, one repo per period" maps onto the existing one-repo-per-tick scheduled-job pattern (`@Scheduled` + ShedLock + backoff), not a new infrastructure mechanism.
-- The 12-week window applies to the commit-derived dimensions (C, A); the issue/PR window is to be confirmed (see §8).
+- A single 12-week window applies to all four dimensions.
 
 ## 13. References
 

--- a/docs/specs/oss-health-metric/spec.md
+++ b/docs/specs/oss-health-metric/spec.md
@@ -1,179 +1,203 @@
-# Spec: OSS Health Metric
-
-**Input:** verbatim seed text — preserved for traceability
-
-> We need to implement OSS Health metric for project. Here is RFC, that contains a section describing this metric: `/Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for author-faced insights.md`. Do a thorough research on the mentioned papers and align the metric to the klibs.io usecase.
-
-> ADJUSTMENT PROMPT:  Archived / disabled GitHub repo -- skip. GitHub returns 202 for /stats/participation or /stats/contributors -- use reliable graphql apis to compute that instead of relying on GH. as for the quota usage: spread it
-across time, don't do heavy job all at once. do one repo per period of time. we also expose ossHealth in the search results DTO, yes. Prefer JPA and HQL for validation.
+# Spec: OSS Health metric
 
 ## 1. Goal
-Compute and expose a per-project **OSS Health** score (0–100) — a composite, research-backed signal of repository activity and responsiveness — so that visitors of a klibs.io project page can judge whether a library is actively maintained without needing to skim GitHub themselves.
+
+Compute a single, research-backed **OSS Health** score (0–100) per project from its GitHub repository activity, and expose it on the project (including in search results) so maintainers and users have a neutral, composite signal of how actively and sustainably a library is maintained.
 
 ## 2. Problem
-- klibs.io currently exposes only point-in-time GitHub fields per repository: `stars`, `open_issues`, `last_activity_ts`, `license`. None of these on their own tell a visitor whether a library is being actively maintained — a high-star library can be abandoned, a low-star one can be healthy.
-- The research the RFC cites ([Iqbal et al., 2023](https://arxiv.org/abs/2309.12120v3)) shows that single raw indicators (stars, commit recency, issue counts) do not reliably identify OSS sustainability. A composite is needed.
-- **Affected:** end users of klibs.io evaluating library trustworthiness; library maintainers who want a neutral, defensible signal of their project's activity surfaced on the platform.
+
+- klibs.io today exposes only single raw signals about a repository (stars, open-issue count, last activity). Used in isolation these are misleading: a high star count says nothing about whether the project is still maintained, and "last commit" alone hides whether activity is steady or sporadic.
+- There is no neutral, composite indicator a maintainer can point to that summarises *maintenance health* — commit cadence, issue/PR responsiveness, and contributor diversity — in one defensible number.
+- Affected: **library authors** (want a fair signal of their maintenance effort) and **end users** browsing/searching klibs.io (want to judge whether a library is actively maintained before adopting it).
 
 ## 3. User scenarios & acceptance
 
-### Scenario 1 — Visitor sees health on a project page (P1)
-- **Given:** a project whose backing GitHub repo has at least 12 weeks of recorded activity and the OSS Health score has been computed.
-- **When:** the visitor opens the project details page (`/project/{ownerLogin}/{projectName}/details`).
-- **Then:** the response includes an `ossHealth` field with an integer 0–100, plus the timestamp at which it was last computed.
-- **Independent test:** seed `scm_repo` + an `oss_health_score` row with a fixture score; call the details endpoint; assert `ossHealth` is present and within [0, 100].
+### Scenario 1 — Actively maintained repo gets a health score (P1)
+- **Given:** a non-archived GitHub repository with regular commits, issues, and merged PRs over the last 12 weeks.
+- **When:** the OSS Health computation runs for that repository.
+- **Then:** a numeric score in `[0,100]` is computed and persisted with status `COMPUTED`, and the value is returned in the project's search-result payload and project-details payload.
+- **Independent test:** seed an `scm_repo` + `project` and a fixture of activity inputs; run the computation; assert via JPA/HQL that a health row exists with status `COMPUTED` and the score matches the formula (§8) for those inputs.
 
-### Scenario 2 — Insufficient data is reported, not hidden silently (P1)
-- **Given:** a project whose backing repo has fewer than 12 weeks of recorded commit/issue/PR activity, OR for which the drip job has not yet picked the repo up.
-- **When:** the visitor opens the project details page.
-- **Then:** `ossHealth` is `null` (or carries an explicit "insufficient data" indicator — see FR-008) and a machine-readable reason is conveyed so the frontend can render *"Insufficient activity data"* rather than a misleading "0".
-- **Independent test:** seed a brand-new repo with one commit; assert the field is `null`/insufficient and not `0`.
+### Scenario 2 — Archived / disabled repo is skipped (P1)
+- **Given:** a GitHub repository whose `isArchived` or `isDisabled` flag is true.
+- **When:** the repository is selected for OSS Health computation.
+- **Then:** no score is computed; the health record's status is `SKIPPED` (not `COMPUTED`), and the project payload exposes `ossHealth` as **null** (not `0`).
+- **Independent test:** mark the repo archived in the GraphQL fixture; run the computation; assert via HQL the status is `SKIPPED` and the API response field is null.
 
-### Scenario 3 — Health refreshes on a predictable cadence (P1)
-- **Given:** a project whose `oss_health_score.computed_at` is older than 7 days (`klibs.oss-health.eligibility-window-days`).
-- **When:** the drip job's next iteration runs.
-- **Then:** that project is the staleest eligible repo, gets picked, and its score is recomputed using the latest 12-week window of commit/issue/PR data; the stored `computed_at` moves forward.
-- **Independent test:** run the drip-job iteration in a test harness with a stubbed `GitHubIntegration`; assert the score row is upserted with the new `computed_at`.
-
-### Scenario 4 — Rate-limit-aware drip (P1)
-- **Given:** the drip job is about to process the next repo, and the remaining GitHub GraphQL points budget is below the safety margin.
-- **When:** the iteration ticks.
-- **Then:** the iteration short-circuits without making a GraphQL call; the repo's `computed_at` is left untouched so it remains eligible on the next tick; a `oss_health_skipped_rate_limit_total` counter increments.
-- **Independent test:** unit test the iteration with a fake `GitHubIntegration.getRateLimitInfo()` that returns `remaining < safetyMargin`; assert no GraphQL call is made and the score row is unchanged.
+### Scenario 3 — Low-activity repo is computed but flagged insufficient (P2)
+- **Given:** a repository with activity below the display threshold (computed score `< 40`, or too little data to compute a meaningful score, e.g. fewer than `[NEEDS CLARIFICATION: minimum weeks of history / minimum commit count to consider data sufficient]`).
+- **When:** the computation runs.
+- **Then:** the API distinguishes three states for the consumer — *not yet computed*, *computed but below the display threshold / insufficient data*, and *computed and displayable* — so the frontend can render "Insufficient activity data" without confusing it with a genuine score of 0.
+- **Independent test:** seed sparse activity; assert the response carries a status/flag distinguishing "insufficient" from a real low score and from "not yet computed".
 
 ### Edge cases
-- **Repo younger than 12 weeks:** report insufficient data. Do not extrapolate (per RFC's "negative impact risk" note — a misleadingly low score is worse than no score).
-- **Repo with zero issues / zero PRs over the window:** the Issue and PR sub-scores have undefined ratios. We treat the sub-component as `0` for the ratio term but **must not** zero out the entire `I` or `P` — see FR-009.
-- **Repo with one contributor:** `TopContributorCommitShare = 1.0`, so the diversity sub-score becomes `0.6 * (1/5) + 0.4 * 0 = 0.12`. This is intended; a one-person project legitimately scores low on diversity.
-- **Archived / disabled GitHub repo:** skip computation entirely. If a score row already exists for the repo, transition it to `status = NOT_APPLICABLE` and null out the integer `score` (so it stops being shown). The drip job filters these out at eligibility-select time.
-- **GitHub stats-endpoint 202s avoided entirely:** we do *not* call REST `/stats/participation` or `/stats/contributors` — both return `HTTP 202 Accepted` on cold reads with no firm completion ceiling. Instead we derive weekly commit buckets and contributor share from a single paginated **GraphQL** commit-history query (see FR-002 and FR-005), which is deterministic and returns the same shape on every call.
-- **Repository renamed / transferred:** the `nativeId` (numeric repo ID) is stable across renames; the score row must key on `scm_repo.id` (which is derived from `nativeId`), not on `owner/name`.
-- **klibs egress NAT IP pool is shared** between `klibs-stage` and `klibs-features`; the drip job's GraphQL points draw must stay within the shared token's 5,000 pts/hr budget and yield well before exhaustion — see NFR-Rate-limits.
+- **Zero commits in the 12-week window** → coefficient of variation is undefined (mean = 0). Treated as insufficient data, not score 0.
+- **Zero issues opened in the window** → issue close ratio `closed/opened` is undefined; the issue dimension contribution must be defined for this case (see §8).
+- **Zero PRs in the window** → same for the PR dimension.
+- **Single contributor** → top-contributor commit share = 1, so the diversity sub-term contribution is 0; this is a valid low (not an error).
+- **Repository younger than the 12-week window** → partial window; treated as insufficient data.
+- **GraphQL call fails / times out for a repo** → the previously persisted score (if any) is retained, the repo is backed off and retried later; one failure does not zero out the score.
+- **GitHub REST `/stats/participation` or `/stats/contributors` returns HTTP 202** → not relied upon; all inputs come from GraphQL instead (see §8).
 
 ## 4. Functional requirements
 
-- **FR-001:** System MUST compute an OSS Health score in `[0, 100]` per scm-repository, defined as `100 * (0.30*C + 0.25*I + 0.25*P + 0.20*A)`, where the four sub-scores `C, I, P, A ∈ [0, 1]` are computed per the formula below.
-- **FR-002:** System MUST compute `C` (Commit Consistency) over the last 12 weeks of weekly commit buckets as `C = max(0, 1 - CV / 0.6)` where `CV = stdev(weekly_commits) / mean(weekly_commits)`. If `mean == 0`, then `C = 0` (no commits = no consistency). Weekly buckets are derived from a paginated **GraphQL** query against `repository.defaultBranchRef.target ... on Commit { history(since: now-12w) { ... committedDate, author { user { login } } } }`; bucket aggregation is done in-process. This deliberately replaces REST `/stats/participation`, which returns `HTTP 202` on cold reads.
-- **FR-003:** System MUST compute `I` (Issue Responsiveness) as `I = 0.5 * min(1, IssueCloseRatio / 0.4) + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)`. Both inputs come from a single paginated **GraphQL** query against `repository.issues(filterBy: { since: now-12w }, orderBy: { field: UPDATED_AT, direction: DESC })` returning `createdAt`, `closedAt`, `state` per issue:
-    - `IssueCloseRatio = issues_closed_in_window / issues_opened_in_window`, both counted from the same result set (an issue counts as "opened in window" if `createdAt >= now-12w`; "closed in window" if `state == CLOSED && closedAt >= now-12w`).
-    - `MedianIssueCloseDays = median(closedAt - createdAt)` in days, over issues closed in the window.
-- **FR-004:** System MUST compute `P` (PR Management) as `P = 0.5 * min(1, PRMergeRatio / 0.5) + 0.5 * max(0, 1 - MedianPRMergeDays / 14)`, with `PRMergeRatio` and `MedianPRMergeDays` derived analogously to FR-003 but via a single paginated **GraphQL** `repository.pullRequests(orderBy: { field: UPDATED_AT, direction: DESC })` query returning `createdAt`, `mergedAt`, `closedAt`, `state` per PR. `PRMergeRatio = prs_merged_in_window / prs_opened_in_window` — a PR closed without merge counts in the denominator but **not** the numerator, per the RFC. `MedianPRMergeDays = median(mergedAt - createdAt)` over PRs *merged* in the window.
-- **FR-005:** System MUST compute `A` (Author Diversity) as `A = 0.6 * min(1, ActiveContributors / 5) + 0.4 * (1 - TopContributorCommitShare)`. Both inputs are derived from the **same GraphQL commit-history result set used for FR-002** (`author.user.login` per commit), with no additional API call: `ActiveContributors` is the count of distinct non-null logins with ≥ 1 commit in the last 12 weeks; `TopContributorCommitShare = top_committer_commits / total_commits` in that window. If `total_commits == 0`, `TopContributorCommitShare = 0` and `ActiveContributors = 0` → `A = 0`. This deliberately replaces REST `/stats/contributors`, which returns `HTTP 202` on cold reads.
-- **FR-006:** System MUST NOT introduce a separate daily snapshot job. All four sub-components' inputs are derived from the three GraphQL queries in the per-repo recompute pass (FR-002 commits, FR-003 issues, FR-004 PRs). The daily-diff plan from the source RFC is obsoleted by the GraphQL switch.
-- **FR-007:** System MUST run the OSS Health recompute as a **drip job**: a `@Scheduled` task that fires every N seconds (default 30s — mirroring `GitHubRepositoryUpdatingJob`'s existing cadence) and processes **exactly one repo per iteration** — picking the staleest eligible repo (`oss_health_score.computed_at IS NULL OR < now() - 7 days`, excluding archived/disabled). This spreads the GitHub GraphQL points draw evenly across the week instead of bursting at a single cron tick, and keeps headroom for the existing 30-second `GitHubRepositoryUpdatingJob` that shares the same PAT + NAT egress. ShedLock name: `computeOssHealthLock`. The "weekly" cadence is a property of the *eligibility window* (`computed_at` cutoff), not the job firing frequency.
-- **FR-008:** System MUST distinguish "score not yet computed" / "insufficient data" from "score is 0". The persisted shape is `(score INT NULL, computed_at TIMESTAMP NULL, status ENUM: OK | INSUFFICIENT_DATA | STALE)`. The API field is nullable; the response also carries a status enum.
-- **FR-009:** System MUST treat *missing* sub-component inputs distinctly from *zero* sub-component inputs. Specifically: if a repo has zero issues opened in the window, its `IssueCloseRatio` ratio term contributes `0` (the project simply didn't get any issues to respond to), but the median term contributes its full `1.0` weight (there were no slow closes either). Same for PRs. The RFC's formula already accommodates this via the `min(1, …)` / `max(0, …)` clamps; this requirement just makes the intent explicit.
-- **FR-010:** System MUST require **at least 12 weeks** of `scm_repo` history (since `created_at`) before computing a score. Repos younger than 12 weeks are marked `INSUFFICIENT_DATA`.
-- **FR-011:** System MUST expose `ossHealth` on **both** API surfaces: `ProjectDetailsDTO` (nullable integer `ossHealth` plus the enum `ossHealthStatus`) and `SearchProjectResult` (nullable integer `ossHealth` only — a `null` is the "do not show" signal for the listing). This requires `project_index` to gain an `oss_health` column (additive view migration).
-- **FR-012:** System MUST be controllable via a `klibs.*` feature toggle so the drip job can be disabled in `local` / `prod` independently (mirroring the existing `klibs.indexing` toggle pattern).
-- **FR-013:** System MUST NOT compute or display an OSS Health score for archived or disabled GitHub repositories. The drip job MUST filter these out at eligibility-select time. If a previously-computed score exists for a repo that has since been archived, the row is updated to `status = NOT_APPLICABLE` and `score` is nulled.
-- **FR-014:** System MUST NOT change the weights / thresholds from the RFC formula without an explicit spec amendment — they are deliberately frozen to the RFC's simplified CSI variant. (See §8 Option A vs B.)
+- **FR-001:** System MUST expose an `ossHealth` field on the **project search-results payload** and on the **project-details payload**, carrying the computed OSS Health score as an integer in `[0,100]`.
+- **FR-002:** The API MUST distinguish "not yet computed" from a computed score, and MUST NOT report a computed score of `0` as equivalent to "no data". (A consumer reading the response can tell the difference.)
+- **FR-003:** System MUST NOT compute or report an OSS Health score for an archived or disabled repository; `ossHealth` for such a project MUST be null/absent rather than `0`.
+- **FR-004:** The OSS Health score MUST be computed according to the formula and input windows defined in §8 (Decision — OSS Health formula). Given a fixed set of activity inputs, the resulting score MUST be deterministic and reproducible.
+- **FR-005:** The API MUST allow the consumer to distinguish a *displayable* score from a *below-threshold / insufficient-data* score, so the frontend can apply the product display rule (hide / show "Insufficient activity data") without inventing its own cutoff. `[NEEDS CLARIFICATION: does the backend gate display at score < 40 by returning a status, or return the raw score plus an "insufficient" flag and let the frontend apply the 40 cutoff?]`
+- **FR-006:** OSS Health scores MUST be refreshed over time so the value reflects recent activity; a stale score MUST eventually be recomputed without manual intervention.
 
 ## 5. Non-functional requirements
 
-- **Performance:** Score computation is offline (job-driven), not request-time. The API read path (`/project/.../details`) MUST add no more than a single indexed lookup on the score table (or a join on `scm_repo_id`). No GitHub API call on the read path.
-- **External rate limits:**
-    - GitHub GraphQL: per-repo cost is **3 GraphQL queries** (commits → C + A, issues → I, PRs → P), each potentially paginated. GraphQL has a complexity-points budget of 5,000 pts/hr per token; each non-paginated query costs ~1 pt and each additional page adds proportionally. Even at a pessimistic ~30 pts/repo, the shared NAT pool comfortably accommodates ~150 repos/hr — well above what the drip job actually consumes.
-    - The drip design (FR-007: one repo every ~30s ⇒ ~120 repos/hr) keeps comfortable headroom for the existing 30-second `GitHubRepositoryUpdatingJob`, which shares the same PAT + NAT egress (see `[[reference_klibs_egress_ips]]`). No burst contention with the existing job; no big-bang weekly cron.
-    - The job MUST still check `GitHubIntegration.getRateLimitInfo()` (extended to surface GraphQL points if not already exposed there) and skip this iteration if `remaining < safetyMargin` (default 200), deferring the repo to the next tick.
-- **Concurrency:** One new ShedLock key: `computeOssHealthLock`. The drip job and the existing `updateGitHubRepositoryLock` job both call GitHub and share the same PAT + NAT egress; the per-iteration rate-limit guard above is what keeps them out of each other's way.
-- **Observability:**
-    - Micrometer counter per new GraphQL query type (`oss_health.graphql.commits`, `oss_health.graphql.issues`, `oss_health.graphql.pulls`) plus pagination-page counters, consistent with the per-request-type pattern already in `GitHubIntegrationKohsukeLibrary`.
-    - Counters / gauges for `oss_health_compute_success_total`, `oss_health_compute_failure_total{reason}`, `oss_health_insufficient_data_total`, `oss_health_skipped_archived_total`, `oss_health_skipped_rate_limit_total`.
-    - INFO log line per repo with the four sub-scores so a surprising final number can be debugged without re-running.
-- **Security:** Read-only endpoint addition (no auth boundary change). The score is non-sensitive aggregate metadata. Contributor logins fetched via GraphQL are used only for the `ActiveContributors` count and `TopContributorCommitShare` aggregation; no GitHub logins are persisted (we store only the resulting numeric `a_component`).
+- **External rate limits — GitHub GraphQL:** The GitHub GraphQL API is metered by a **point budget of 5000 points/hour per authenticated token** (point-based, *not* per-IP). klibs.io uses a single personal access token (`klibs.integration.github.personal-access-token`), so this budget is shared across all replicas and across the existing REST jobs that use the same token — independent of the shared Cloud NAT egress IPs. The OSS Health job MUST stay within this budget alongside existing GitHub traffic.
+- **Concurrency / scheduling:** Computation MUST be spread across time — **one repository per scheduled tick** — rather than processing all repositories in a single heavy batch. The job MUST hold a distinct ShedLock lock so only one instance runs at a time. Per-repo failures MUST back off and retry (reuse the existing backoff pattern) without blocking other repos.
+- **Performance / staleness:** Each repository's score should be refreshed on roughly a **weekly** cadence. With one repo per tick, the tick interval is derived from the repository count and the target refresh window. `[NEEDS CLARIFICATION: current count of active (non-archived) repositories and the acceptable maximum staleness, to size the tick interval]`
+- **Observability:** Add a Micrometer counter/timer for OSS Health computations (success / skipped / failed) and a gauge for the count of repos pending (re)computation, consistent with the existing GitHub-integration metrics.
 
 ## 6. Out of scope
 
-- Author-facing analytics (the P3 items in the RFC: page views, snippet copies, outbound clicks, search impressions/clicks). Those depend on the GitHub OAuth flow described in the RFC's "Authentication" section — separate spec.
-- Number-of-dependents (P1 in the RFC) — already in the codebase (`project.dependent_count`). Not part of this spec.
-- Maven downloads, pub.dev–style Likes/Points, trending. Not in this spec.
-- Triangular-membership / fuzzy normalization from the original CSI paper (arXiv 2504.00542). We deliberately use the RFC's simplified linear-with-clamps form — see §8.
-- Repository-centrality network analysis (arXiv 2405.07508). Explicitly rejected by the RFC as "too much computation for klibs purposes."
-- Showing a numeric score below a display cutoff (the RFC suggests "show only if ≥ 40, else *Insufficient activity data*"). The **backend always returns the score**; the **display cutoff is a frontend concern**, except that we expose the `status` enum (FR-008) so the frontend can implement the rule trivially.
-- Showing more than just `ossHealth` on search results — the listing surfaces the integer score only (or hides it on `null`). The `ossHealthStatus` enum is details-page-only.
+- Number-of-dependents metric (already implemented as `dependent_count`), Google-Analytics-based metrics (page views, search impressions/clicks, snippet copies, outbound clicks), and the author-authentication / GitHub-OAuth work — these are separate RFC line items (P1 / P3) and separate specs.
+- Maven Central download counts (no reliable public API).
+- Sorting or filtering search results by OSS Health (this spec only *exposes* the field; sorting is not requested).
+- GitHub's native `health_percentage` (community-files metric) — not part of this composite.
+- Backfill/recompute-all tooling beyond the rolling scheduled refresh.
+- Frontend rendering of the score and the "Insufficient activity data" copy (frontend consumes the contract from FR-001/FR-005).
 
 ## 7. Klibs.io technical surface
 
 - **Modules touched:**
-    - `core/scm-repository` — new sub-package `oss-health` (or a sibling module `core/oss-health`) housing the `OssHealthScore` JPA entity, repository, and the calculator. Keeps concerns out of `ScmRepositoryEntity` itself.
-    - `integrations/github` — new GraphQL-backed methods on `GitHubIntegration`: `getCommitsSince(repositoryId, since): List<CommitMeta>` (returns `committedDate` + `authorLogin`), `getIssuesActivitySince(repositoryId, since): List<IssueActivity>` (`createdAt`, `closedAt`, `state`), `getPullRequestsActivitySince(repositoryId, since): List<PrActivity>` (`createdAt`, `mergedAt`, `closedAt`, `state`). The existing Kohsuke client is REST-only; the GraphQL queries go through the existing OkHttp + GitHub PAT path. New per-query micrometer counters. **No 202 handling needed** — GraphQL does not stall on these queries.
-    - `app` — new scheduled drip job; new Liquibase migration; wiring in `ProjectDetailsService` and the search-results assembly path to surface the score.
-    - `core/project` — additive change to `ProjectDetailsDTO`.
-    - `core/search` — additive change to `SearchProjectResult` and the `project_index` materialized-view SQL.
-- **Database:**
-    - New JPA-managed table `oss_health_score`: `scm_repo_id INT PK (FK to scm_repo)`, `score INT NULL`, `status VARCHAR (enum: OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE)`, `c_component NUMERIC(4,3)`, `i_component NUMERIC(4,3)`, `p_component NUMERIC(4,3)`, `a_component NUMERIC(4,3)`, `computed_at TIMESTAMP NULL`. Storing the sub-components alongside the final score makes debugging and a future "why is my score X?" breakdown trivial.
-    - **No daily snapshot table** (per FR-006) — all inputs come from the per-iteration GraphQL pass.
-    - Additive change to the `project_index` materialized view: gain a nullable `oss_health INT` column, sourced from `LEFT JOIN oss_health_score ON oss_health_score.scm_repo_id = project.scm_repo_id`. The view's defining SELECT is updated; a `LEFT JOIN` keeps it null-tolerant for repos with no score yet.
-    - Migration folder: `app/src/main/resources/db/migration/2026-Q2/` (current quarter per the survey).
-    - Additive-only: yes. No backfill of historical data needed — GraphQL pulls the last 12 weeks of history in one pass, so a mature repo can be scored on its first eligible drip tick post-deploy.
-- **Persistence style:** **JPA + HQL** for the new `oss_health_score` table. Rationale per maintainer guidance: HQL gives compile-time-checked queries against the JPA model and a stronger validation surface than raw JDBC, and there's no high-throughput hot-path on this table (one read per details fetch — served via the materialized view for search — and one upsert per repo per eligibility window).
-- **Search / materialized views:**
-    - `project_index` gains a nullable `oss_health INT` column via a `LEFT JOIN` on the new `oss_health_score` table. Refresh cadence is unchanged (the existing 10-minute `MaterializedViewUpdatingJob` picks it up via `REFRESH MATERIALIZED VIEW CONCURRENTLY`). The view is recreated in the new migration (drop + create — note Liquibase additive-migration policy per `[[feedback_ask_before_additive_migration]]`).
-    - `package_index` is unaffected (per-package, not per-project).
-- **External integrations:**
-    - GitHub GraphQL API (single endpoint `https://api.github.com/graphql`). Three queries per repo per recompute: `repository.defaultBranchRef.target ... on Commit { history }` (commits over 12 weeks), `repository.issues(filterBy: { since: ... })` (issue activity), `repository.pullRequests(orderBy: UPDATED_AT)` (PR activity). All paginate via standard `pageInfo { endCursor hasNextPage }`.
-    - **No `HTTP 202` handling needed** — GraphQL does not stall on stats. Standard 5xx / secondary-rate-limit retry-after handling applies.
-    - Authentication uses the existing `klibs.integration.github.personalAccessToken`. Scope: `public_repo` is sufficient.
-- **Scheduled jobs:**
-    - One new job: `OssHealthComputeJob`, `@Scheduled(fixedRate = 30s, initialDelay = 30s)` (rate configurable via `klibs.oss-health.fixed-rate-ms`). ShedLock name `computeOssHealthLock`. Each iteration: pick the single staleest eligible repo (`oss_health_score.computed_at IS NULL OR < now() - 7 days` AND repo is not archived/disabled), run the three GraphQL queries, compute, upsert. **No batch fan-out**, no per-cron burst.
-    - No daily snapshot job. The existing `GitHubRepositoryUpdatingJob` is unchanged.
-    - Idempotency: upsert keyed by `scm_repo_id`. Re-running for the same repo within the same eligibility window MUST yield an identical score (deterministic computation from the same 12-week window).
-- **Storage:** No S3 / no local cache impact. README handling is untouched.
-- **Configuration:** New `klibs.oss-health.*` properties — `enabled: Boolean = true`, `fixed-rate-ms: Long = 30_000`, `eligibility-window-days: Int = 7`, `rate-limit-safety-margin: Int = 200`. Profile defaults: enabled in `local` and `prod`; disabled in `test` via property override (per `[[feedback_property_toggles_over_profile]]`).
-- **API surface:** Additive changes to **two** DTOs: `ProjectDetailsDTO` gains nullable `ossHealth: Int?` and `ossHealthStatus: String` (or enum); `SearchProjectResult` gains nullable `ossHealth: Int?` (status enum omitted — `null` is the "do not show" signal). OpenAPI doc auto-regenerates. **Not** a breaking change.
-- **Frontend contract:** `klibs-frontend` needs to:
-    1. Render the new field on **both** the project-details page (using `ossHealth` + `ossHealthStatus`) and the search-results listing (using `ossHealth` only — render nothing when null).
-    2. On the details page, apply the RFC's "show only if ≥ 40, else *Insufficient activity data*" rule client-side, driven by the `ossHealthStatus` enum.
-    3. Optionally render a tooltip explaining the four sub-scores (the breakdown is stored server-side; a future `/oss-health/{projectId}/breakdown` endpoint is cheap to add — out of scope for v1).
+  - `integrations/github` — add a GraphQL-based capability to fetch commit history, issues, and PRs (new methods on `GitHubIntegration`).
+  - `core/scm-repository` — new persisted OSS Health data keyed to the repository, plus a JPA entity + repository for it.
+  - `core/search` — add `ossHealth` to `project_index`, `SearchProjectResult`, `SearchProjectResultDTO`, and the row mapper.
+  - `core/project` — add `ossHealth` to `ProjectDetailsDTO`.
+  - `app` — new `@Scheduled` job (one repo per tick) + service wiring.
+- **Database:** New table for health, keyed by `scm_repo` (one row per repository). Stores: composite score, the four component sub-scores (commit consistency, issue responsiveness, PR management, author diversity), a status enum (`COMPUTED`, `INSUFFICIENT_DATA`, `SKIPPED`, and the implicit "no row yet" = not computed), and a `computed_at` timestamp. Additive-only migration in `db/migration/2026-Q2/` (current quarter). Column types/index choices are plan-level. Backfill: none required — rows are created by the rolling job.
+- **Persistence style:** **JPA + HQL** for the new health entity/repository and for test validation, per the explicit request. This deliberately diverges from the JDBC pattern used elsewhere in `core/scm-repository` (`ScmRepositoryRepositoryJdbc`); see §8.
+- **Search / materialized views:** `project_index` must be recreated to add the `ossHealth` column (join `project → scm_repo → oss health`), following the existing recreate-view-with-new-column migration pattern (e.g. the `dependent_count` recreation). `package_index` unaffected.
+- **External integrations:** GitHub **GraphQL** (`https://api.github.com/graphql`) for commit history (weekly buckets + per-author counts), issues (created/closed timestamps), and PRs (created/merged timestamps). Existing REST `/stats/participation` and `/stats/contributors` are intentionally **not** used (they return 202 while GitHub computes stats asynchronously, which is unreliable for an on-demand job). Per-repo backoff/retry.
+- **Scheduled jobs:** New `@Scheduled` job in `app`, one repository per tick, distinct `@SchedulerLock` name (e.g. `updateOssHealthLock`), selecting the stalest health record (analogous to `findMultipleForUpdate`). Idempotent: recomputing yields the same score for the same inputs.
+- **Configuration:** New `klibs.*` properties for the job cadence and (optionally) the display threshold; default the job **on** but make it disableable via a property toggle (so it can be suppressed in tests/environments). No profile gating.
+- **API surface:** Additive field `ossHealth` on the search-results and project-details responses; update OpenAPI docs. Additive only — not a breaking change.
+- **Frontend contract:** `klibs-frontend` will need to read `ossHealth` and the displayable/insufficient state, and render "Insufficient activity data" below the threshold. Out of scope here but the contract (FR-001, FR-005) is the dependency.
 
-## 8. Design options considered
+## 8. Design decisions
 
-### Option A — Paper-faithful CSI (triangular membership functions)
-Use the original CSI paper's normalization: each sub-component is normalized via a triangular function with the paper's target values (`μ_c = 0.25, σ_c = 0.25`, etc.) and the paper's stability thresholds (CSI ≥ 0.7 = stable).
+### Decision — OSS Health formula (simplified CSI, monotonic)
+- **Choice:** Adopt the four-dimension Composite Stability Index from *Introducing Repository Stability* (arXiv 2504.00542), but with the simplified, **monotonic** normalization the RFC settled on (more activity → higher score, capped at 1), rather than the paper's bell-shaped `ϕ(x)=1−|x−μ|/σ` that also penalises "too much" activity. Weights are kept from the paper.
 
-- **Pros:** Defensible against academic critique; the paper's authors picked those constants for a reason.
-- **Cons:** The paper itself is "conceptual" and "open to debate"; empirical validation is acknowledged-pending. Triangular membership functions are non-monotonic — a repo can score *worse* by getting *more* commits than the target, which is counterintuitive for authors and harder to explain.
+  ```
+  OssHealth = round(100 * (0.30*C + 0.25*I + 0.25*P + 0.20*A))
 
-### Option B — RFC's simplified linear-with-clamps form (recommended)
-Use the formula in the RFC verbatim: linear normalization clamped by `min(1, x / threshold)` for "more is better" terms and `max(0, 1 - y / threshold)` for "less is better" terms. Always monotonic.
+  # C — Commit consistency (12-week window)
+  #   CV = stddev / mean of the 12 weekly commit counts   (population CV; RFC's "mean/std" is a typo)
+  C = max(0, 1 - CV / 0.6)
 
-- **Pros:** Monotonic and explainable — "more closed issues is always better, up to the cap"; the RFC's thresholds (`IssueCloseRatio / 0.4`, `MedianIssueCloseDays / 21`, `PRMergeRatio / 0.5`, `MedianPRMergeDays / 14`, `ActiveContributors / 5`) are concrete and reviewable. Simpler to implement and to defend to an author who asks "why did my score drop?"
-- **Cons:** Less "faithful" to the source paper; thresholds are picked by the RFC author, not from a published study. (Mitigation: the [Iqbal et al. paper](https://arxiv.org/abs/2309.12120v3) the RFC cites supports the *idea* of a composite over single signals but does not prescribe specific constants — so any choice is a judgment call.)
+  # I — Issue responsiveness (window: see clarification below)
+  IssueCloseRatio   = issuesClosedInWindow / issuesOpenedInWindow
+  MedianIssueCloseDays = median close time of issues closed in window
+  I = 0.5 * min(1, IssueCloseRatio / 0.4)
+    + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)
 
-### Option C — Recompute on-demand from raw GitHub (no persistence)
-Cache nothing; compute on first request per project per week and cache in-process.
+  # P — Pull-request management
+  PRMergeRatio     = prsMergedInWindow / prsOpenedInWindow
+  MedianPRMergeDays = median merge time of PRs merged in window
+  P = 0.5 * min(1, PRMergeRatio / 0.5)
+    + 0.5 * max(0, 1 - MedianPRMergeDays / 14)
 
-- **Pros:** Minimal schema change; trivially correct.
-- **Cons:** Hot path now depends on GitHub availability; shared NAT IP rate limits make this fragile under traffic; defeats the entire premise of a precomputed score.
+  # A — Author diversity (12-week window)
+  ActiveContributors        = distinct authors with >=1 commit in last 12 weeks
+  TopContributorCommitShare = top author's commits / total commits in window
+  A = 0.6 * min(1, ActiveContributors / 5)
+    + 0.4 * (1 - TopContributorCommitShare)
+  ```
+- **Why:** The paper's bell-shaped normalization would penalise very active projects (e.g. a high commit rate scores *lower*), which is counter-intuitive and demoralising for an author-facing signal — contrary to the RFC anti-goal "don't make authors feel bad". Monotonic-capped terms are easier to explain and defend. Weights `[0.30, 0.25, 0.25, 0.20]` are taken unchanged from the paper. Using a composite (rather than any single raw metric) is itself supported by arXiv 2309.12120, which finds single context-free indicators insufficient for sustainability judgments.
+- **Rejected:**
+  - *Paper-exact CSI* (bell-shaped `ϕ`, target values μ/σ) — penalises healthy high activity; harder to explain.
+  - *Repository-centrality / network-lifespan model* (arXiv 2405.07508) — requires building a cross-repo user–repository graph; far too much computation for klibs.io's per-repo budget.
+  - *Single raw metric* (stars / last-commit / issue count alone) — rejected on the evidence of arXiv 2309.12120.
+- **Revisit if:** authors report the score feels unfair, or the chosen target constants (0.6, 0.4, 21d, 0.5, 14d, 5, etc.) produce poorly-distributed scores on real data — these constants should be validated against a sample of indexed repos before launch.
+- **Open:** `[NEEDS CLARIFICATION: the window for issue/PR opened/closed ratios and medians — the commit terms use 12 weeks; do the issue/PR ratios use the same 12 weeks, the RFC's per-day deltas, or a longer window such as 90 days?]` and the zero-denominator handling: `[NEEDS CLARIFICATION: when issuesOpenedInWindow == 0 (or prsOpenedInWindow == 0), is that dimension scored 0, omitted with weights renormalised, or treated as insufficient data?]`
 
-**Decision:** **Option B**. Rationale: matches the RFC author's intent; monotonic and explainable; thresholds are reviewable in this spec rather than buried in a paper's appendix. Option A can be revisited if Option B's scores prove poorly calibrated against a hand-labeled sample of known-healthy / known-abandoned repos — but that's empirical follow-up work, not a v1 concern.
+### Decision — Compute all inputs from GitHub GraphQL, not REST stats or daily snapshots
+- **Choice:** Fetch every input via the GitHub GraphQL API: commit history over 12 weeks (yields both weekly buckets for C *and* per-author commit counts for A in one traversal), `issues` with `createdAt`/`closedAt`, and `pullRequests` with `createdAt`/`mergedAt`. Read `isArchived`/`isDisabled` from the same GraphQL repository query to drive the skip decision.
+- **Why:** The REST `/stats/participation` and `/stats/contributors` endpoints return HTTP 202 while GitHub computes stats asynchronously and are unreliable for an on-demand job (user-confirmed). The RFC's "daily diff snapshot of openIssueCount" approach is also unsound here: GitHub's open-issue count *includes PRs*, so deltas can't separate the issue and PR dimensions — GraphQL gives clean, separately-queryable issue and PR sets with exact timestamps. A single commit-history traversal covers two of the four dimensions.
+- **Rejected:** REST `/stats/*` (202 / async, unreliable); daily snapshot deltas (conflates issues+PRs, only nets, no medians).
+- **Revisit if:** GraphQL point cost per repo proves too high for the weekly cadence within the 5000 pts/hr shared budget.
+
+### Decision — New GraphQL client over existing OkHttp, no new dependency
+- **Choice:** Implement GraphQL calls by POSTing queries to `api.github.com/graphql` using the already-present OkHttp client and the existing GitHub PAT, exposed as new methods on `GitHubIntegration`. The kohsuke `github-api` library (used for all current REST calls) does not provide first-class GraphQL support.
+- **Why:** Avoids adding a GraphQL-client dependency (CLAUDE.md: avoid dependency upgrades), reuses existing auth and HTTP infrastructure and the existing Micrometer/metrics conventions.
+- **Rejected:** Adding a dedicated GraphQL client library — unnecessary dependency for a handful of queries.
+
+### Decision — Persist health in a new JPA-mapped table keyed by `scm_repo`
+- **Choice:** A new table (one row per repository) holding composite score, the four sub-scores, a status enum, and `computed_at`. Accessed via a **JPA entity + Spring Data JPA repository**, with validation/tests using **HQL**.
+- **Why:** Keys to the repository because the metric is entirely repository-derived (and avoids recomputation if multiple projects ever map to one repo); persisting the four sub-scores keeps the score auditable/explainable and supports HQL-based test assertions. JPA+HQL is the user's explicit preference for this feature.
+- **Rejected:** Raw JDBC (`ScmRepositoryRepositoryJdbc` style) — matches the module's existing pattern but the user explicitly preferred JPA/HQL here; storing only the composite score (no sub-scores) — loses explainability and makes the formula untestable component-by-component.
+- **Tension to confirm:** CLAUDE.md says "match the existing persistence pattern in the touched module" (JDBC). Using JPA here is a deliberate, user-requested divergence — flag for reviewer.
+
+### Decision — Rolling one-repo-per-tick scheduled job with backoff
+- **Choice:** A new `@Scheduled` job that picks the single stalest health record each tick, computes its score, persists it, and applies the existing exponential backoff on failure. Distinct ShedLock lock `updateOssHealthLock`.
+- **Why:** Mirrors the proven `GitHubRepositoryUpdatingJob` pattern (`findMultipleForUpdate` + `BackoffProvider`), spreads GraphQL point usage smoothly across the hour/week (user-requested), and keeps the heavy work off any single tick.
+- **Rejected:** One heavy weekly batch over all repos — spikes the GraphQL budget and risks long lock-holds / partial failures.
 
 ## 9. Key entities
 
-- **OssHealthScore:** one row per `scm_repo`. JPA-managed. Stores the final integer score, the four sub-components (`c, i, p, a` as numeric for debugging), a status enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`), and a `computed_at` timestamp. Lifecycle: created lazily on first successful drip-job run for a repo; refreshed when `computed_at` becomes older than 7 days; transitions to `NOT_APPLICABLE` if the parent repo is archived/disabled; deleted only if the parent `scm_repo` is deleted (cascade).
+- **`OssHealthEntity`** (working name): one row per `scm_repo`.
+  - **Key fields:** `scmRepoId` (FK / identity to `scm_repo`), `score` (0–100, nullable when not displayable), `commitConsistency`, `issueResponsiveness`, `prManagement`, `authorDiversity` (the four component sub-scores in `[0,1]`), `status` (`COMPUTED` / `INSUFFICIENT_DATA` / `SKIPPED`), `computedAt` (Instant; JVMs run UTC, map Instant ↔ TIMESTAMP accordingly).
+  - **Relationships:** one-to-one with `ScmRepositoryEntity`; surfaced per `project` via `project.scm_repo_id`.
+  - **Lifecycle:** created/updated by the rolling job; absence of a row = "not yet computed"; `SKIPPED` for archived/disabled repos; recomputed on the weekly cadence.
 
-## 10. Test strategy
+## 10. Database schema diagram
 
-- **Unit:**
-    - `OssHealthCalculator` (pure function from `(weeklyCommits, openedClosedIssueCounts, medianIssueDays, openedClosedPrCounts, medianPrDays, activeContributors, topShare) -> Int score + components`). Test the formula edge cases: zero commits (C=0), zero issues, zero PRs, single contributor, perfectly balanced repo. Cover the FR-009 "missing vs zero" semantics with explicit cases.
-    - Drip-job iteration unit test (with mocked `GitHubIntegration`) that verifies: (a) rate-limit yield (Scenario 4) defers the repo without state change, (b) an archived/disabled repo is filtered out at eligibility-select time without an API call, (c) idempotency — running the same iteration twice produces identical score rows.
-- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses for the new `OssHealthScore` JPA repository. Method-level `@Sql` seeds per `[[feedback_sql_seed_method_level]]`. Verify upsert idempotency and that the `project_index` materialized-view refresh picks up new score rows via the `LEFT JOIN`.
-- **Web / smoke:** `SmokeTestBase` test that hits `/project/.../details` against a seeded fixture and asserts the new fields appear in the JSON response with the expected shape (null case and populated case). A second `SmokeTestBase` test on the search endpoint asserts `ossHealth` is present in `SearchProjectResult` JSON.
-- *Reviewer-only — manual / staging:* deploy to `klibs-features` (per `[[feedback_never_prod_unprompted]]`), let the drip job run for a few hours, watch the new counters in the actuator output, spot-check 3–5 known repos (one obviously healthy, one obviously abandoned, one new) and confirm the scores feel directionally right. Compare against GraphQL points-budget headroom on the shared NAT IP pool.
+```mermaid
+erDiagram
+    PROJECT ||--|| SCM_REPO : "scm_repo_id"
+    SCM_REPO ||--o| OSS_HEALTH : "scm_repo_id"
+    SCM_REPO {
+        int id PK
+        int stars
+        int open_issues
+        string license_name
+    }
+    OSS_HEALTH {
+        int scm_repo_id PK_FK "(new)"
+        int score "(new) nullable"
+        float commit_consistency "(new)"
+        float issue_responsiveness "(new)"
+        float pr_management "(new)"
+        float author_diversity "(new)"
+        string status "(new) COMPUTED/INSUFFICIENT_DATA/SKIPPED"
+        timestamp computed_at "(new)"
+    }
+    PROJECT {
+        int id PK
+        int scm_repo_id FK
+        int dependent_count
+    }
+```
 
-## 11. Assumptions
+## 11. Test strategy
 
-- Per-repo GraphQL pagination is capped at ~3 pages (≤ 300 items) per query for issues and PRs. If a repo has more than 300 closed issues / PRs in 12 weeks, the median over the first 300 is a fine approximation; commit-history pagination is uncapped (we need all commits in the window for accurate weekly buckets and contributor share, but in practice 12 weeks of commits stays well within a handful of pages for typical klibs libraries).
-- **No cold-start warmup**: because the GraphQL queries pull the last 12 weeks of history directly, a mature repo can be scored on its first eligible drip-job tick post-deploy. Only repos with `scm_repo.created_at > now - 12 weeks` are `INSUFFICIENT_DATA` (FR-010).
-- Display semantics (`≥ 40 ⇒ show number`, `< 40 ⇒ show "Insufficient activity data"`) are a frontend concern. The backend always returns the raw number when computable; the `ossHealthStatus` enum is the contract. This separation lets us tune the display cutoff later without re-deploying the backend.
-- The numeric `nativeId` of a GitHub repo is stable across renames/transfers (GitHub's documented behavior); we key the new table off `scm_repo.id`, which already keys off `nativeId`.
+- **Unit:** Score calculator class — pure function of activity inputs → score; cover each dimension, the zero-denominator edge cases, the CV-undefined case, and a full worked example (pin exact score for a fixed input set). Mock the GraphQL boundary; test the archived/disabled skip path.
+- **DB-integration:** `BaseUnitWithDbLayerTest` subclass with method-level `@Sql` seeds; persist a health row and assert via **HQL / the JPA repository** that the score, sub-scores, and status round-trip and that the project-search join surfaces `ossHealth` correctly (and null for `SKIPPED`).
+- **Web / smoke:** `SmokeTestBase` — assert `ossHealth` appears in the search-results and project-details responses, and that "not computed" vs "insufficient" vs a real score are distinguishable in the JSON.
+- **Reviewer-only — manual / staging:** On `klibs-features`, let the rolling job run against real repositories; validate the score distribution looks sane (not all clustered at 0 or 100), confirm archived repos are skipped, and confirm the GraphQL point budget stays within 5000/hr alongside existing GitHub jobs.
 
-## 12. References
+## 12. Assumptions
 
-- RFC, source of truth for this spec: `/Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for author-faced insights.md`.
-- *Introducing Repository Stability* — arXiv [2504.00542](https://arxiv.org/abs/2504.00542) (2025). Source of the CSI formula structure (weights 0.30 / 0.25 / 0.25 / 0.20). Paper acknowledges its "conceptual phase" status; we adopt the four-dimension structure but **not** its triangular-membership normalization (see §8).
-- *Individual context-free online community health indicators fail to identify open source software sustainability* — arXiv [2309.12120v3](https://arxiv.org/abs/2309.12120v3) (2023, rev. 2024). Motivates the composite-over-single-metric choice; cited in problem statement.
-- *Revealing the value of Repository Centrality in lifespan prediction of OSS Projects* — arXiv [2405.07508](https://arxiv.org/abs/2405.07508) (2024). Explicitly out of scope per the RFC (too compute-heavy).
-- Existing klibs.io entities referenced: `ScmRepositoryEntity` (`core/scm-repository`), `ProjectDetailsDTO` (`core/project`), `GitHubIntegration` (`integrations/github`), `project_index` materialized view (`core/search`).
-- Memory: `[[reference_klibs_egress_ips]]` (shared NAT pool — rate-limit budget is per-IP, not per-replica), `[[reference_ghratelimit_record_ctor]]` (kohsuke ctor-order gotcha), `[[feedback_property_toggles_over_profile]]`, `[[feedback_sql_seed_method_level]]`, `[[feedback_ask_before_additive_migration]]`.
+- A `project` maps to exactly one `scm_repo` (1:1) for the purpose of exposing the score; keying health by `scm_repo` therefore yields one value per project.
+- The single existing GitHub PAT has GraphQL access and sufficient point budget to add a weekly-per-repo health pass on top of current REST traffic.
+- The RFC's chosen simplified formula (and its weights/constants) is the intended contract; the paper-exact CSI is reference only.
+- "Spread across time, one repo per period" maps onto the existing one-repo-per-tick scheduled-job pattern (`@Scheduled` + ShedLock + backoff), not a new infrastructure mechanism.
+- The 12-week window applies to the commit-derived dimensions (C, A); the issue/PR window is to be confirmed (see §8).
+
+## 13. References
+
+- RFC: *Author insights for klibs.io* (KTL-4246), section "OSS Health index".
+- *Introducing Repository Stability* — arXiv 2504.00542 (2025): source of the four-dimension CSI, weights `[0.30, 0.25, 0.25, 0.20]`, and per-dimension definitions.
+- *Individual context-free online community health indicators fail to identify open source software sustainability* — arXiv 2309.12120 (2023, rev. 2024): justification for a composite over any single raw metric.
+- *Revealing the value of Repository Centrality in lifespan prediction of OSS Projects* — arXiv 2405.07508 (2024): considered and rejected (too compute-heavy).
+- Existing pattern references in-repo: `app/.../job/GitHubRepositoryUpdatingJob.kt`, `core/scm-repository/.../ScmRepositoryRepositoryJdbc.kt`, `core/search/.../SearchProjectResultDTO.kt`, the `2026-Q2` `dependent_count` column + `project_index` recreation migrations.
+</content>
+</invoke>

--- a/docs/specs/oss-health-metric/spec.md
+++ b/docs/specs/oss-health-metric/spec.md
@@ -4,6 +4,9 @@
 
 > We need to implement OSS Health metric for project. Here is RFC, that contains a section describing this metric: `/Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for author-faced insights.md`. Do a thorough research on the mentioned papers and align the metric to the klibs.io usecase.
 
+> ADJUSTMENT PROMPT:  Archived / disabled GitHub repo -- skip. GitHub returns 202 for /stats/participation or /stats/contributors -- use reliable graphql apis to compute that instead of relying on GH. as for the quota usage: spread it
+across time, don't do heavy job all at once. do one repo per period of time. we also expose ossHealth in the search results DTO, yes. Prefer JPA and HQL for validation.
+
 ## 1. Goal
 Compute and expose a per-project **OSS Health** score (0–100) — a composite, research-backed signal of repository activity and responsiveness — so that visitors of a klibs.io project page can judge whether a library is actively maintained without needing to skim GitHub themselves.
 
@@ -18,66 +21,67 @@ Compute and expose a per-project **OSS Health** score (0–100) — a composite,
 - **Given:** a project whose backing GitHub repo has at least 12 weeks of recorded activity and the OSS Health score has been computed.
 - **When:** the visitor opens the project details page (`/project/{ownerLogin}/{projectName}/details`).
 - **Then:** the response includes an `ossHealth` field with an integer 0–100, plus the timestamp at which it was last computed.
-- **Independent test:** seed `scm_repo` + the new snapshot/stats tables with a fixture worth of activity; call the details endpoint; assert `ossHealth` is present and within [0, 100].
+- **Independent test:** seed `scm_repo` + an `oss_health_score` row with a fixture score; call the details endpoint; assert `ossHealth` is present and within [0, 100].
 
 ### Scenario 2 — Insufficient data is reported, not hidden silently (P1)
-- **Given:** a project whose backing repo has fewer than 12 weeks of recorded commit/issue/PR activity, OR for which the heavy weekly job has not yet succeeded.
+- **Given:** a project whose backing repo has fewer than 12 weeks of recorded commit/issue/PR activity, OR for which the drip job has not yet picked the repo up.
 - **When:** the visitor opens the project details page.
 - **Then:** `ossHealth` is `null` (or carries an explicit "insufficient data" indicator — see FR-008) and a machine-readable reason is conveyed so the frontend can render *"Insufficient activity data"* rather than a misleading "0".
 - **Independent test:** seed a brand-new repo with one commit; assert the field is `null`/insufficient and not `0`.
 
-### Scenario 3 — Health updates on a predictable cadence (P1)
-- **Given:** a project that has had an OSS Health score computed.
-- **When:** the weekly recomputation job runs.
-- **Then:** the score is updated using the latest 12-week window of commit/issue/PR/contributor data, and the stored `computed_at` timestamp moves forward.
-- **Independent test:** run the job in a test harness with a stubbed `GitHubIntegration`; assert the score row is upserted with the new `computed_at`.
+### Scenario 3 — Health refreshes on a predictable cadence (P1)
+- **Given:** a project whose `oss_health_score.computed_at` is older than 7 days (`klibs.oss-health.eligibility-window-days`).
+- **When:** the drip job's next iteration runs.
+- **Then:** that project is the staleest eligible repo, gets picked, and its score is recomputed using the latest 12-week window of commit/issue/PR data; the stored `computed_at` moves forward.
+- **Independent test:** run the drip-job iteration in a test harness with a stubbed `GitHubIntegration`; assert the score row is upserted with the new `computed_at`.
 
-### Scenario 4 — Rate-limit-aware refresh (P1)
-- **Given:** the heavy weekly job is running through a backlog of projects, each costing ~5–10 GitHub API calls.
-- **When:** the remaining GitHub rate-limit budget drops below a safe threshold.
-- **Then:** the job pauses/yields without failing the overall scheduled run, and resumes on the next iteration without dropping any project.
-- **Independent test:** unit test the job loop with a fake `GitHubIntegration.getRateLimitInfo()` that returns low remaining; assert the loop exits cleanly and the un-processed projects are still queued.
+### Scenario 4 — Rate-limit-aware drip (P1)
+- **Given:** the drip job is about to process the next repo, and the remaining GitHub GraphQL points budget is below the safety margin.
+- **When:** the iteration ticks.
+- **Then:** the iteration short-circuits without making a GraphQL call; the repo's `computed_at` is left untouched so it remains eligible on the next tick; a `oss_health_skipped_rate_limit_total` counter increments.
+- **Independent test:** unit test the iteration with a fake `GitHubIntegration.getRateLimitInfo()` that returns `remaining < safetyMargin`; assert no GraphQL call is made and the score row is unchanged.
 
 ### Edge cases
 - **Repo younger than 12 weeks:** report insufficient data. Do not extrapolate (per RFC's "negative impact risk" note — a misleadingly low score is worse than no score).
 - **Repo with zero issues / zero PRs over the window:** the Issue and PR sub-scores have undefined ratios. We treat the sub-component as `0` for the ratio term but **must not** zero out the entire `I` or `P` — see FR-009.
 - **Repo with one contributor:** `TopContributorCommitShare = 1.0`, so the diversity sub-score becomes `0.6 * (1/5) + 0.4 * 0 = 0.12`. This is intended; a one-person project legitimately scores low on diversity.
-- **Archived / disabled GitHub repo:** [NEEDS CLARIFICATION: do we skip computation for archived repos (and clear any existing score), or compute as normal so the score decays naturally?]
-- **GitHub returns 202 for `/stats/participation` or `/stats/contributors`** (stats not yet cached on GitHub's side): retry on the next weekly run; do not fail the job. The previously-computed score is retained until the next successful run.
-- **Repository renamed / transferred:** the `nativeId` (numeric repo ID) is stable across renames; snapshots and history must key on `nativeId`, not on `owner/name`.
-- **klibs egress NAT IP pool is shared** between `klibs-stage` and `klibs-features`; with ~5–10 calls per repo per week and N projects, the heavy job must stay within the shared GitHub PAT budget (5,000 req/hr authenticated) and yield well before exhaustion — see NFR-Rate-limits.
+- **Archived / disabled GitHub repo:** skip computation entirely. If a score row already exists for the repo, transition it to `status = NOT_APPLICABLE` and null out the integer `score` (so it stops being shown). The drip job filters these out at eligibility-select time.
+- **GitHub stats-endpoint 202s avoided entirely:** we do *not* call REST `/stats/participation` or `/stats/contributors` — both return `HTTP 202 Accepted` on cold reads with no firm completion ceiling. Instead we derive weekly commit buckets and contributor share from a single paginated **GraphQL** commit-history query (see FR-002 and FR-005), which is deterministic and returns the same shape on every call.
+- **Repository renamed / transferred:** the `nativeId` (numeric repo ID) is stable across renames; the score row must key on `scm_repo.id` (which is derived from `nativeId`), not on `owner/name`.
+- **klibs egress NAT IP pool is shared** between `klibs-stage` and `klibs-features`; the drip job's GraphQL points draw must stay within the shared token's 5,000 pts/hr budget and yield well before exhaustion — see NFR-Rate-limits.
 
 ## 4. Functional requirements
 
 - **FR-001:** System MUST compute an OSS Health score in `[0, 100]` per scm-repository, defined as `100 * (0.30*C + 0.25*I + 0.25*P + 0.20*A)`, where the four sub-scores `C, I, P, A ∈ [0, 1]` are computed per the formula below.
-- **FR-002:** System MUST compute `C` (Commit Consistency) over the last 12 weeks of weekly commit buckets from GitHub `GET /repos/{owner}/{repo}/stats/participation` as `C = max(0, 1 - CV / 0.6)` where `CV = stdev(weekly_commits) / mean(weekly_commits)`. If `mean == 0`, then `C = 0` (no commits = no consistency).
-- **FR-003:** System MUST compute `I` (Issue Responsiveness) as `I = 0.5 * min(1, IssueCloseRatio / 0.4) + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)`, where:
-    - `IssueCloseRatio = issues_closed_in_window / issues_opened_in_window` over the last 12 weeks, derived from the daily diff snapshots.
-    - `MedianIssueCloseDays` is computed by paginating issues closed within the last 12 weeks (`GET /repos/{owner}/{repo}/issues?state=closed&since=...`) and taking the median of `(closed_at - created_at)` in days.
-- **FR-004:** System MUST compute `P` (PR Management) as `P = 0.5 * min(1, PRMergeRatio / 0.5) + 0.5 * max(0, 1 - MedianPRMergeDays / 14)`, with `PRMergeRatio` and `MedianPRMergeDays` defined analogously to FR-003 but for PRs (`GET /repos/{owner}/{repo}/pulls?state=closed&since=...`, filtered to merged).
-- **FR-005:** System MUST compute `A` (Author Diversity) as `A = 0.6 * min(1, ActiveContributors / 5) + 0.4 * (1 - TopContributorCommitShare)`, using `GET /repos/{owner}/{repo}/stats/contributors`. `ActiveContributors` is the count of distinct contributors with at least one commit in the last 12 weeks; `TopContributorCommitShare = top_committer_commits / total_commits` in that window. If `total_commits == 0`, `TopContributorCommitShare = 0` and `ActiveContributors = 0` → `A = 0`.
-- **FR-006:** System MUST run a **daily diff snapshot** job that records, per `scm_repo`, `open_issues_total` (and PR equivalent if obtainable cheaply) so that `opened_delta` and `closed_delta` can be derived without paginating issues each day. This piggybacks on the existing 30-second `GitHubRepositoryUpdatingJob` and adds no extra GitHub calls.
-- **FR-007:** System MUST run a **weekly heavy job** that, per repo, calls `/stats/participation`, `/stats/contributors`, and paginates closed issues + closed PRs since `now - 12 weeks` to compute medians; then computes the final OSS Health score and upserts it. ShedLock name: `computeOssHealthLock`. Cadence: [NEEDS CLARIFICATION: exact weekly cron — e.g., Sundays 03:00 UTC, or staggered to avoid clashing with the daily 02:00 Maven indexing job mentioned in CLAUDE.md].
+- **FR-002:** System MUST compute `C` (Commit Consistency) over the last 12 weeks of weekly commit buckets as `C = max(0, 1 - CV / 0.6)` where `CV = stdev(weekly_commits) / mean(weekly_commits)`. If `mean == 0`, then `C = 0` (no commits = no consistency). Weekly buckets are derived from a paginated **GraphQL** query against `repository.defaultBranchRef.target ... on Commit { history(since: now-12w) { ... committedDate, author { user { login } } } }`; bucket aggregation is done in-process. This deliberately replaces REST `/stats/participation`, which returns `HTTP 202` on cold reads.
+- **FR-003:** System MUST compute `I` (Issue Responsiveness) as `I = 0.5 * min(1, IssueCloseRatio / 0.4) + 0.5 * max(0, 1 - MedianIssueCloseDays / 21)`. Both inputs come from a single paginated **GraphQL** query against `repository.issues(filterBy: { since: now-12w }, orderBy: { field: UPDATED_AT, direction: DESC })` returning `createdAt`, `closedAt`, `state` per issue:
+    - `IssueCloseRatio = issues_closed_in_window / issues_opened_in_window`, both counted from the same result set (an issue counts as "opened in window" if `createdAt >= now-12w`; "closed in window" if `state == CLOSED && closedAt >= now-12w`).
+    - `MedianIssueCloseDays = median(closedAt - createdAt)` in days, over issues closed in the window.
+- **FR-004:** System MUST compute `P` (PR Management) as `P = 0.5 * min(1, PRMergeRatio / 0.5) + 0.5 * max(0, 1 - MedianPRMergeDays / 14)`, with `PRMergeRatio` and `MedianPRMergeDays` derived analogously to FR-003 but via a single paginated **GraphQL** `repository.pullRequests(orderBy: { field: UPDATED_AT, direction: DESC })` query returning `createdAt`, `mergedAt`, `closedAt`, `state` per PR. `PRMergeRatio = prs_merged_in_window / prs_opened_in_window` — a PR closed without merge counts in the denominator but **not** the numerator, per the RFC. `MedianPRMergeDays = median(mergedAt - createdAt)` over PRs *merged* in the window.
+- **FR-005:** System MUST compute `A` (Author Diversity) as `A = 0.6 * min(1, ActiveContributors / 5) + 0.4 * (1 - TopContributorCommitShare)`. Both inputs are derived from the **same GraphQL commit-history result set used for FR-002** (`author.user.login` per commit), with no additional API call: `ActiveContributors` is the count of distinct non-null logins with ≥ 1 commit in the last 12 weeks; `TopContributorCommitShare = top_committer_commits / total_commits` in that window. If `total_commits == 0`, `TopContributorCommitShare = 0` and `ActiveContributors = 0` → `A = 0`. This deliberately replaces REST `/stats/contributors`, which returns `HTTP 202` on cold reads.
+- **FR-006:** System MUST NOT introduce a separate daily snapshot job. All four sub-components' inputs are derived from the three GraphQL queries in the per-repo recompute pass (FR-002 commits, FR-003 issues, FR-004 PRs). The daily-diff plan from the source RFC is obsoleted by the GraphQL switch.
+- **FR-007:** System MUST run the OSS Health recompute as a **drip job**: a `@Scheduled` task that fires every N seconds (default 30s — mirroring `GitHubRepositoryUpdatingJob`'s existing cadence) and processes **exactly one repo per iteration** — picking the staleest eligible repo (`oss_health_score.computed_at IS NULL OR < now() - 7 days`, excluding archived/disabled). This spreads the GitHub GraphQL points draw evenly across the week instead of bursting at a single cron tick, and keeps headroom for the existing 30-second `GitHubRepositoryUpdatingJob` that shares the same PAT + NAT egress. ShedLock name: `computeOssHealthLock`. The "weekly" cadence is a property of the *eligibility window* (`computed_at` cutoff), not the job firing frequency.
 - **FR-008:** System MUST distinguish "score not yet computed" / "insufficient data" from "score is 0". The persisted shape is `(score INT NULL, computed_at TIMESTAMP NULL, status ENUM: OK | INSUFFICIENT_DATA | STALE)`. The API field is nullable; the response also carries a status enum.
 - **FR-009:** System MUST treat *missing* sub-component inputs distinctly from *zero* sub-component inputs. Specifically: if a repo has zero issues opened in the window, its `IssueCloseRatio` ratio term contributes `0` (the project simply didn't get any issues to respond to), but the median term contributes its full `1.0` weight (there were no slow closes either). Same for PRs. The RFC's formula already accommodates this via the `min(1, …)` / `max(0, …)` clamps; this requirement just makes the intent explicit.
 - **FR-010:** System MUST require **at least 12 weeks** of `scm_repo` history (since `created_at`) before computing a score. Repos younger than 12 weeks are marked `INSUFFICIENT_DATA`.
-- **FR-011:** System MUST expose `ossHealth` (nullable integer) and `ossHealthStatus` (enum) on `ProjectDetailsDTO`. [NEEDS CLARIFICATION: do we also expose `ossHealth` in the search results DTO (`SearchProjectResult`) — i.e., on the `project_index` materialized view — for ranking or display, or only on the details endpoint?]
-- **FR-012:** System MUST be controllable via a `klibs.*` feature toggle so the heavy weekly job can be disabled in `local` / `prod` independently (mirroring the existing `klibs.indexing` toggle pattern).
-- **FR-013:** System MUST NOT compute or display an OSS Health score for archived or disabled GitHub repositories — pending FR-edge-case clarification above. [NEEDS CLARIFICATION: confirm.]
+- **FR-011:** System MUST expose `ossHealth` on **both** API surfaces: `ProjectDetailsDTO` (nullable integer `ossHealth` plus the enum `ossHealthStatus`) and `SearchProjectResult` (nullable integer `ossHealth` only — a `null` is the "do not show" signal for the listing). This requires `project_index` to gain an `oss_health` column (additive view migration).
+- **FR-012:** System MUST be controllable via a `klibs.*` feature toggle so the drip job can be disabled in `local` / `prod` independently (mirroring the existing `klibs.indexing` toggle pattern).
+- **FR-013:** System MUST NOT compute or display an OSS Health score for archived or disabled GitHub repositories. The drip job MUST filter these out at eligibility-select time. If a previously-computed score exists for a repo that has since been archived, the row is updated to `status = NOT_APPLICABLE` and `score` is nulled.
 - **FR-014:** System MUST NOT change the weights / thresholds from the RFC formula without an explicit spec amendment — they are deliberately frozen to the RFC's simplified CSI variant. (See §8 Option A vs B.)
 
 ## 5. Non-functional requirements
 
 - **Performance:** Score computation is offline (job-driven), not request-time. The API read path (`/project/.../details`) MUST add no more than a single indexed lookup on the score table (or a join on `scm_repo_id`). No GitHub API call on the read path.
 - **External rate limits:**
-    - GitHub: heavy job costs ~5 calls per repo (`/stats/participation` + `/stats/contributors` + ≥1 page of closed issues + ≥1 page of closed PRs + occasional retry on 202). With ~5,000/hr authenticated budget and the klibs-stage / klibs-features shared NAT pool (see `[[reference_klibs_egress_ips]]`), the job must process repos serially with rate-limit checks, not in parallel bursts.
-    - The job MUST check `GitHubIntegration.getRateLimitInfo()` before each repo and yield if `remaining < safetyMargin` (margin TBD; recommend ≥ 200 to leave headroom for the existing 30-second `GitHubRepositoryUpdatingJob` running concurrently).
-- **Concurrency:** New ShedLock keys: `computeOssHealthLock` (weekly heavy job) and — if we add a separate daily diff snapshot job rather than piggybacking — `snapshotScmRepoMetricsLock`. The heavy job and existing `updateGitHubRepositoryLock` job both call GitHub; they share the same egress IP / PAT and therefore the same rate-limit pool — see above.
+    - GitHub GraphQL: per-repo cost is **3 GraphQL queries** (commits → C + A, issues → I, PRs → P), each potentially paginated. GraphQL has a complexity-points budget of 5,000 pts/hr per token; each non-paginated query costs ~1 pt and each additional page adds proportionally. Even at a pessimistic ~30 pts/repo, the shared NAT pool comfortably accommodates ~150 repos/hr — well above what the drip job actually consumes.
+    - The drip design (FR-007: one repo every ~30s ⇒ ~120 repos/hr) keeps comfortable headroom for the existing 30-second `GitHubRepositoryUpdatingJob`, which shares the same PAT + NAT egress (see `[[reference_klibs_egress_ips]]`). No burst contention with the existing job; no big-bang weekly cron.
+    - The job MUST still check `GitHubIntegration.getRateLimitInfo()` (extended to surface GraphQL points if not already exposed there) and skip this iteration if `remaining < safetyMargin` (default 200), deferring the repo to the next tick.
+- **Concurrency:** One new ShedLock key: `computeOssHealthLock`. The drip job and the existing `updateGitHubRepositoryLock` job both call GitHub and share the same PAT + NAT egress; the per-iteration rate-limit guard above is what keeps them out of each other's way.
 - **Observability:**
-    - Micrometer counter for each new GitHub call type (`stats_participation`, `stats_contributors`, `issues_paginated`, `pulls_paginated`), consistent with the existing per-request-type counters in `GitHubIntegrationKohsukeLibrary`.
-    - Counter / gauge for `oss_health_compute_success_total`, `oss_health_compute_failure_total{reason}`, `oss_health_insufficient_data_total`.
-    - Log line per repo at INFO with the four sub-scores so we can debug a surprising final number without re-running.
-- **Security:** Read-only endpoint addition (no auth boundary change). The score is non-sensitive aggregate metadata. No personal data is persisted beyond the *count* of contributors (no logins stored in the snapshot table).
+    - Micrometer counter per new GraphQL query type (`oss_health.graphql.commits`, `oss_health.graphql.issues`, `oss_health.graphql.pulls`) plus pagination-page counters, consistent with the per-request-type pattern already in `GitHubIntegrationKohsukeLibrary`.
+    - Counters / gauges for `oss_health_compute_success_total`, `oss_health_compute_failure_total{reason}`, `oss_health_insufficient_data_total`, `oss_health_skipped_archived_total`, `oss_health_skipped_rate_limit_total`.
+    - INFO log line per repo with the four sub-scores so a surprising final number can be debugged without re-running.
+- **Security:** Read-only endpoint addition (no auth boundary change). The score is non-sensitive aggregate metadata. Contributor logins fetched via GraphQL are used only for the `ActiveContributors` count and `TopContributorCommitShare` aggregation; no GitHub logins are persisted (we store only the resulting numeric `a_component`).
 
 ## 6. Out of scope
 
@@ -87,38 +91,41 @@ Compute and expose a per-project **OSS Health** score (0–100) — a composite,
 - Triangular-membership / fuzzy normalization from the original CSI paper (arXiv 2504.00542). We deliberately use the RFC's simplified linear-with-clamps form — see §8.
 - Repository-centrality network analysis (arXiv 2405.07508). Explicitly rejected by the RFC as "too much computation for klibs purposes."
 - Showing a numeric score below a display cutoff (the RFC suggests "show only if ≥ 40, else *Insufficient activity data*"). The **backend always returns the score**; the **display cutoff is a frontend concern**, except that we expose the `status` enum (FR-008) so the frontend can implement the rule trivially.
-- Backfilling historical commit / issue / PR data older than what GitHub returns in a single call window. We start the window at `now`; the first 12 weeks after rollout will yield `INSUFFICIENT_DATA` for the issue-delta-derived ratio terms unless we explicitly backfill — see §11 assumption.
+- Showing more than just `ossHealth` on search results — the listing surfaces the integer score only (or hides it on `null`). The `ossHealthStatus` enum is details-page-only.
 
 ## 7. Klibs.io technical surface
 
 - **Modules touched:**
-    - `core/scm-repository` — new sub-entity / table for the OSS Health score and the daily delta snapshot; possibly a new sub-package `oss-health` to keep concerns isolated (or a sibling module `core/oss-health` — see §8 Option B vs C).
-    - `integrations/github` — new methods on `GitHubIntegration`: `getWeeklyCommitParticipation(repositoryId)`, `getContributorStats(repositoryId)`, `listClosedIssuesSince(repositoryId, since)`, `listClosedPullRequestsSince(repositoryId, since)`. New per-request micrometer counters. Possibly a `BusyException`-equivalent for 202 responses.
-    - `app` — new scheduled job(s); new Liquibase migration; wiring in `ProjectDetailsService` (or wherever `ProjectDetailsDTO` is assembled) to read the score.
+    - `core/scm-repository` — new sub-package `oss-health` (or a sibling module `core/oss-health`) housing the `OssHealthScore` JPA entity, repository, and the calculator. Keeps concerns out of `ScmRepositoryEntity` itself.
+    - `integrations/github` — new GraphQL-backed methods on `GitHubIntegration`: `getCommitsSince(repositoryId, since): List<CommitMeta>` (returns `committedDate` + `authorLogin`), `getIssuesActivitySince(repositoryId, since): List<IssueActivity>` (`createdAt`, `closedAt`, `state`), `getPullRequestsActivitySince(repositoryId, since): List<PrActivity>` (`createdAt`, `mergedAt`, `closedAt`, `state`). The existing Kohsuke client is REST-only; the GraphQL queries go through the existing OkHttp + GitHub PAT path. New per-query micrometer counters. **No 202 handling needed** — GraphQL does not stall on these queries.
+    - `app` — new scheduled drip job; new Liquibase migration; wiring in `ProjectDetailsService` and the search-results assembly path to surface the score.
     - `core/project` — additive change to `ProjectDetailsDTO`.
+    - `core/search` — additive change to `SearchProjectResult` and the `project_index` materialized-view SQL.
 - **Database:**
-    - New table `scm_repo_metrics_daily` (or similar): `scm_repo_id INT PK part`, `snapshot_date DATE PK part`, `open_issues_total INT`, `[NEEDS CLARIFICATION: do we want open_prs_total here too — GHRepository.openIssueCount lumps issues + PRs together, so we'd need a cheap separate read, or accept lumping]`, retention policy TBD (recommend 90 days rolling).
-    - New table `oss_health_score`: `scm_repo_id INT PK`, `score INT NULL`, `status VARCHAR/ENUM`, `c_component NUMERIC`, `i_component NUMERIC`, `p_component NUMERIC`, `a_component NUMERIC`, `computed_at TIMESTAMP NULL`. Storing the sub-components alongside the final score makes both debugging and a future "why is my score X?" author breakdown trivial.
+    - New JPA-managed table `oss_health_score`: `scm_repo_id INT PK (FK to scm_repo)`, `score INT NULL`, `status VARCHAR (enum: OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE)`, `c_component NUMERIC(4,3)`, `i_component NUMERIC(4,3)`, `p_component NUMERIC(4,3)`, `a_component NUMERIC(4,3)`, `computed_at TIMESTAMP NULL`. Storing the sub-components alongside the final score makes debugging and a future "why is my score X?" breakdown trivial.
+    - **No daily snapshot table** (per FR-006) — all inputs come from the per-iteration GraphQL pass.
+    - Additive change to the `project_index` materialized view: gain a nullable `oss_health INT` column, sourced from `LEFT JOIN oss_health_score ON oss_health_score.scm_repo_id = project.scm_repo_id`. The view's defining SELECT is updated; a `LEFT JOIN` keeps it null-tolerant for repos with no score yet.
     - Migration folder: `app/src/main/resources/db/migration/2026-Q2/` (current quarter per the survey).
-    - Additive-only: yes. No backfill of historical data; FR-010 covers the cold-start period.
-- **Persistence style:** `scm-repository` currently mixes JPA entities and raw SQL. Match the existing style of `ScmRepositoryRepository` for the new sub-entity. [NEEDS CLARIFICATION: confirm whether the maintainer prefers JPA or raw JDBC for the new score/snapshot tables — both are present in the module.]
+    - Additive-only: yes. No backfill of historical data needed — GraphQL pulls the last 12 weeks of history in one pass, so a mature repo can be scored on its first eligible drip tick post-deploy.
+- **Persistence style:** **JPA + HQL** for the new `oss_health_score` table. Rationale per maintainer guidance: HQL gives compile-time-checked queries against the JPA model and a stronger validation surface than raw JDBC, and there's no high-throughput hot-path on this table (one read per details fetch — served via the materialized view for search — and one upsert per repo per eligibility window).
 - **Search / materialized views:**
-    - `project_index` will need a new column `oss_health` and the view's `CREATE OR REPLACE MATERIALIZED VIEW` SQL updated **only if** FR-011 clarification lands on "expose in search results." Otherwise the score lives in a side table joined at details-fetch time only.
+    - `project_index` gains a nullable `oss_health INT` column via a `LEFT JOIN` on the new `oss_health_score` table. Refresh cadence is unchanged (the existing 10-minute `MaterializedViewUpdatingJob` picks it up via `REFRESH MATERIALIZED VIEW CONCURRENTLY`). The view is recreated in the new migration (drop + create — note Liquibase additive-migration policy per `[[feedback_ask_before_additive_migration]]`).
     - `package_index` is unaffected (per-package, not per-project).
 - **External integrations:**
-    - GitHub REST API endpoints added: `GET /repos/{owner}/{repo}/stats/participation`, `GET /repos/{owner}/{repo}/stats/contributors`, paginated `GET /repos/{owner}/{repo}/issues?state=closed&since=…`, paginated `GET /repos/{owner}/{repo}/pulls?state=closed&since=…`.
-    - GitHub may return `HTTP 202 Accepted` from the `/stats/*` endpoints on first access while it generates the stats; the integration MUST treat 202 as "retry next week," not as an error.
-    - Retry / backoff: piggyback on whatever the existing kohsuke wrapper does for transient errors. No new backoff scheme.
+    - GitHub GraphQL API (single endpoint `https://api.github.com/graphql`). Three queries per repo per recompute: `repository.defaultBranchRef.target ... on Commit { history }` (commits over 12 weeks), `repository.issues(filterBy: { since: ... })` (issue activity), `repository.pullRequests(orderBy: UPDATED_AT)` (PR activity). All paginate via standard `pageInfo { endCursor hasNextPage }`.
+    - **No `HTTP 202` handling needed** — GraphQL does not stall on stats. Standard 5xx / secondary-rate-limit retry-after handling applies.
+    - Authentication uses the existing `klibs.integration.github.personalAccessToken`. Scope: `public_repo` is sufficient.
 - **Scheduled jobs:**
-    - New `OssHealthComputeJob` (`@Scheduled` weekly, e.g. `cron = "0 0 3 * * SUN"`); ShedLock name `computeOssHealthLock`. Iterates over `scm_repo` rows where `oss_health_score.computed_at IS NULL OR < now() - 7 days`.
-    - Either extend `GitHubRepositoryUpdatingJob` to also write a row into `scm_repo_metrics_daily` (preferred — no extra API calls), or add a tiny daily job that walks `scm_repo` and writes snapshots from the *already-stored* `open_issues` value. Either way, **no new GitHub calls per day**.
-    - Idempotency: both jobs upsert keyed by `(scm_repo_id, snapshot_date)` / `scm_repo_id`. Re-running the weekly job for the same repo on the same day MUST yield the same score (i.e., must not double-count anything).
+    - One new job: `OssHealthComputeJob`, `@Scheduled(fixedRate = 30s, initialDelay = 30s)` (rate configurable via `klibs.oss-health.fixed-rate-ms`). ShedLock name `computeOssHealthLock`. Each iteration: pick the single staleest eligible repo (`oss_health_score.computed_at IS NULL OR < now() - 7 days` AND repo is not archived/disabled), run the three GraphQL queries, compute, upsert. **No batch fan-out**, no per-cron burst.
+    - No daily snapshot job. The existing `GitHubRepositoryUpdatingJob` is unchanged.
+    - Idempotency: upsert keyed by `scm_repo_id`. Re-running for the same repo within the same eligibility window MUST yield an identical score (deterministic computation from the same 12-week window).
 - **Storage:** No S3 / no local cache impact. README handling is untouched.
-- **Configuration:** New `klibs.oss-health.*` properties — `enabled: Boolean = true`, `weekly-cron: String = "0 0 3 * * SUN"`, `repos-per-iteration: Int = N`, `rate-limit-safety-margin: Int = 200`. Profile defaults: enabled in `local` and `prod`; disabled in `test` (see `[[feedback_property_toggles_over_profile]]`).
-- **API surface:** Additive change to `ProjectDetailsDTO`: new nullable `ossHealth: Int?` and `ossHealthStatus: String` (or enum). OpenAPI doc auto-regenerates. **Not** a breaking change.
+- **Configuration:** New `klibs.oss-health.*` properties — `enabled: Boolean = true`, `fixed-rate-ms: Long = 30_000`, `eligibility-window-days: Int = 7`, `rate-limit-safety-margin: Int = 200`. Profile defaults: enabled in `local` and `prod`; disabled in `test` via property override (per `[[feedback_property_toggles_over_profile]]`).
+- **API surface:** Additive changes to **two** DTOs: `ProjectDetailsDTO` gains nullable `ossHealth: Int?` and `ossHealthStatus: String` (or enum); `SearchProjectResult` gains nullable `ossHealth: Int?` (status enum omitted — `null` is the "do not show" signal). OpenAPI doc auto-regenerates. **Not** a breaking change.
 - **Frontend contract:** `klibs-frontend` needs to:
-    1. Render the new field, with the RFC's "show only if ≥ 40, else *Insufficient activity data*" rule applied client-side.
-    2. Optionally render a tooltip explaining the four sub-scores (the breakdown is stored server-side per FR-table-design, so a future `/oss-health/{projectId}/breakdown` endpoint is cheap to add — out of scope for v1).
+    1. Render the new field on **both** the project-details page (using `ossHealth` + `ossHealthStatus`) and the search-results listing (using `ossHealth` only — render nothing when null).
+    2. On the details page, apply the RFC's "show only if ≥ 40, else *Insufficient activity data*" rule client-side, driven by the `ossHealthStatus` enum.
+    3. Optionally render a tooltip explaining the four sub-scores (the breakdown is stored server-side; a future `/oss-health/{projectId}/breakdown` endpoint is cheap to add — out of scope for v1).
 
 ## 8. Design options considered
 
@@ -144,25 +151,23 @@ Cache nothing; compute on first request per project per week and cache in-proces
 
 ## 9. Key entities
 
-- **OssHealthScore:** one row per `scm_repo`. Stores the final integer score, the four sub-components (`c, i, p, a` as numeric for debugging), a status enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`), and a `computed_at` timestamp. Lifecycle: created lazily on first successful weekly run for a repo; updated weekly; deleted only if the parent `scm_repo` is deleted (cascade).
-- **ScmRepoMetricsDailySnapshot:** rolling daily snapshot of fields needed for issue/PR ratio derivation. Composite PK `(scm_repo_id, snapshot_date)`. Lifecycle: appended once per repo per day by the existing 30s job (or a thin new daily job); pruned to the last ~90 days (12 weeks + headroom).
+- **OssHealthScore:** one row per `scm_repo`. JPA-managed. Stores the final integer score, the four sub-components (`c, i, p, a` as numeric for debugging), a status enum (`OK | INSUFFICIENT_DATA | STALE | NOT_APPLICABLE`), and a `computed_at` timestamp. Lifecycle: created lazily on first successful drip-job run for a repo; refreshed when `computed_at` becomes older than 7 days; transitions to `NOT_APPLICABLE` if the parent repo is archived/disabled; deleted only if the parent `scm_repo` is deleted (cascade).
 
 ## 10. Test strategy
 
 - **Unit:**
     - `OssHealthCalculator` (pure function from `(weeklyCommits, openedClosedIssueCounts, medianIssueDays, openedClosedPrCounts, medianPrDays, activeContributors, topShare) -> Int score + components`). Test the formula edge cases: zero commits (C=0), zero issues, zero PRs, single contributor, perfectly balanced repo. Cover the FR-009 "missing vs zero" semantics with explicit cases.
-    - Job loop unit test (with mocked `GitHubIntegration`) that verifies rate-limit yield (Scenario 4) and that 202 responses cause the repo to be skipped without state change.
-- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses for the new score/snapshot repositories. Method-level `@Sql` seeds per `[[feedback_sql_seed_method_level]]`. Verify upsert idempotency.
-- **Web / smoke:** `SmokeTestBase` test that hits `/project/.../details` against a seeded fixture and asserts the new fields appear in the JSON response with the expected shape, including the null case (FR-008) and a populated case.
-- *Reviewer-only — manual / staging:* deploy to `klibs-features` (per `[[feedback_never_prod_unprompted]]`), run the weekly job manually with `repos-per-iteration` set low, watch the new counters in the actuator output, spot-check 3–5 known repos (one obviously healthy, one obviously abandoned, one new) and confirm the scores feel directionally right. Compare against rate-limit headroom on the shared NAT IP pool.
+    - Drip-job iteration unit test (with mocked `GitHubIntegration`) that verifies: (a) rate-limit yield (Scenario 4) defers the repo without state change, (b) an archived/disabled repo is filtered out at eligibility-select time without an API call, (c) idempotency — running the same iteration twice produces identical score rows.
+- **DB-integration:** `BaseUnitWithDbLayerTest` subclasses for the new `OssHealthScore` JPA repository. Method-level `@Sql` seeds per `[[feedback_sql_seed_method_level]]`. Verify upsert idempotency and that the `project_index` materialized-view refresh picks up new score rows via the `LEFT JOIN`.
+- **Web / smoke:** `SmokeTestBase` test that hits `/project/.../details` against a seeded fixture and asserts the new fields appear in the JSON response with the expected shape (null case and populated case). A second `SmokeTestBase` test on the search endpoint asserts `ossHealth` is present in `SearchProjectResult` JSON.
+- *Reviewer-only — manual / staging:* deploy to `klibs-features` (per `[[feedback_never_prod_unprompted]]`), let the drip job run for a few hours, watch the new counters in the actuator output, spot-check 3–5 known repos (one obviously healthy, one obviously abandoned, one new) and confirm the scores feel directionally right. Compare against GraphQL points-budget headroom on the shared NAT IP pool.
 
 ## 11. Assumptions
 
-- The RFC's "Heavy weekly job (5-10 API calls per repo)" is a soft upper bound; for repos with many closed issues/PRs the pagination cost grows. We assume a `Link: next` cap of ~3 pages (300 items) per endpoint is sufficient to compute medians representative of the 12-week window. If a repo has more than 300 closed issues in 12 weeks, the median over the first 300 is a fine approximation.
-- The first 12 weeks after rollout will have only forward-going daily delta data, so the `IssueCloseRatio` and `PRMergeRatio` terms will only be reliable for windows starting at deploy time. We accept that the **first ~3 months post-deploy** is a warmup during which many repos report `INSUFFICIENT_DATA`. Alternative — backfilling via `GET /issues?state=closed&since=12wk_ago` for every repo at deploy time — is feasible but expensive; we defer that decision (see §6 out-of-scope).
-- The `GitHubRepositoryUpdatingJob`'s 30-second cadence (3 repos per run = ~360 repos/hour) is comfortably faster than the weekly cadence of the heavy job, so the daily-diff piggyback in FR-006 will populate `scm_repo_metrics_daily` for every repo within ~hours. We assume the heavy job runs *after* enough daily snapshots exist (≥ 84 days of snapshots) — for the first 12 weeks post-rollout, repos will be `INSUFFICIENT_DATA`.
-- Display semantics (`>= 40 ⇒ show number`, `< 40 ⇒ show "Insufficient activity data"`) are a frontend concern. The backend always returns the raw number when computable; the `status` enum is the contract. This separation lets us tune the display cutoff later without re-deploying the backend.
-- The numeric `nativeId` of a GitHub repo is stable across renames/transfers (this is GitHub's documented behavior); we key all new tables off `scm_repo.id`, which already keys off `nativeId`.
+- Per-repo GraphQL pagination is capped at ~3 pages (≤ 300 items) per query for issues and PRs. If a repo has more than 300 closed issues / PRs in 12 weeks, the median over the first 300 is a fine approximation; commit-history pagination is uncapped (we need all commits in the window for accurate weekly buckets and contributor share, but in practice 12 weeks of commits stays well within a handful of pages for typical klibs libraries).
+- **No cold-start warmup**: because the GraphQL queries pull the last 12 weeks of history directly, a mature repo can be scored on its first eligible drip-job tick post-deploy. Only repos with `scm_repo.created_at > now - 12 weeks` are `INSUFFICIENT_DATA` (FR-010).
+- Display semantics (`≥ 40 ⇒ show number`, `< 40 ⇒ show "Insufficient activity data"`) are a frontend concern. The backend always returns the raw number when computable; the `ossHealthStatus` enum is the contract. This separation lets us tune the display cutoff later without re-deploying the backend.
+- The numeric `nativeId` of a GitHub repo is stable across renames/transfers (GitHub's documented behavior); we key the new table off `scm_repo.id`, which already keys off `nativeId`.
 
 ## 12. References
 


### PR DESCRIPTION
This is a prototype of a spec-to-code approach setup.
It should work something like this:

1. User calls `/specify *vague unstructured description of what needs to be done*`
2. Command tries to fill out the spec template; leaves out places for clarifications and questions.
3. User refines spec manually or with AI; discussions happen.
4. Spec is finalized on the PR. <-- Documentation.
-----
5. User calls `/plan` to create an implementation plan.
6. Command tries to fill out the plan template; leaves out places for clarifications and questions.
7. User refines plan manually or with AI; discussions happen.
8. Plan is finalized on the PR.
-----
9. User calls `/implement`; agent implements according to plan.
10. User adjusts implementation details and accesses the result.
11. Iterates.
12. Code goes on PR; reviewer might do a full review, quick review, or skip it at all <-- Potential win; bottleneck eased.
-----
Spec prompt:
```
 /specify We need to implement OSS Health metric for project. Here is RFC,  
  that contains a section describing this metric:                            
  /Users/nikita.vlaev/Downloads/KTL-4246 Exploratory research for            
  author-faced insights.md. Do a thorough research on the mentioned papers   
  and align the metric to the klibs.io usecase.  Archived / disabled GitHub  
  repo -- skip. GitHub returns 202 for /stats/participation or               
  /stats/contributors -- use reliable graphql apis to compute that instead   
  of relying on GH. as for the quota usage: spread it                        
  across time, don't do heavy job all at once. do one repo per period of     
  time. we also expose ossHealth in the search results DTO, yes. Prefer JPA  
  and HQL for validation.
  ```
 Spec total cost: $4.32
 
  -----
TODO:
1. Explain `/spike` and `/spec-from-spike`
2. Iterate on the "plan" command and template.
3. Add an agentic review in the pipeline