### PR TITLE
KTL-4386: tuned oss health scores

### DIFF
--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -90,9 +90,9 @@ klibs:
         prefix: ${KLIBS_GMAVEN_S3_PREFIX:gmaven}
   ai: true
   oss-health:
-    commit-cv-denominator: 1.0
+    commit-cv-denominator: 3.0
     issue-median-days-threshold: 21.0
-    pr-median-days-threshold: 5.0
+    pr-median-days-threshold: 10.0
     active-contributors-target: 5
 
 management:

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/health/OssHealthProperties.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/health/OssHealthProperties.kt
@@ -15,10 +15,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class OssHealthProperties(
     /**
      * Denominator in C = max(0, 1 − CV / denominator).
-     * Observed CVs for real OSS repos sit around 0.5–1.3; 1.0 puts the "average"
-     * project near the middle of the score range.
+     * Calibrated against the live catalog CV distribution (≈520 repos): median CV ≈ 1.8,
+     * with a hard pileup at √11 ≈ 3.32 for repos active in only one of the last 12 weeks.
+     * 3.0 scores consistently-committing repos well (CV ≈ 0.5–1.1 → C ≈ 0.6–0.8) while
+     * still flooring the genuinely sporadic tail (CV ≥ 3) at 0.
      */
-    val commitCvDenominator: Double = 1.0,
+    val commitCvDenominator: Double = 3.0,
 
     /**
      * Median-days threshold for the issue-responsiveness median term.
@@ -28,9 +30,11 @@ data class OssHealthProperties(
 
     /**
      * Median-days threshold for the PR-management median term.
-     * Aligns with τ_p = 5 days from Destefanis et al. 2025.
+     * The paper's τ_p = 5 days proved too strict for thorough-review libraries (catalog
+     * PR-merge medians: p75 ≈ 2d, p90 ≈ 15d); 10 days credits careful-but-timely review
+     * without rewarding the genuinely-slow tail.
      */
-    val prMedianDaysThreshold: Double = 5.0,
+    val prMedianDaysThreshold: Double = 10.0,
 
     /**
      * Denominator for the "active contributors" term of author diversity.

--- a/frontend/src/app/faq/page.tsx
+++ b/frontend/src/app/faq/page.tsx
@@ -17,6 +17,7 @@ const POM_EXAMPLE_URL =
     "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0/kotlinx-coroutines-core-1.8.0.pom";
 const TOOLING_METADATA_EXAMPLE_URL =
     "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.8.0/kotlinx-coroutines-core-1.8.0-kotlin-tooling-metadata.json";
+const REPOSITORY_STABILITY_PAPER_URL = "https://arxiv.org/abs/2504.00542";
 
 export default function Faq() {
     return (
@@ -109,6 +110,45 @@ export default function Faq() {
                         platforms. Ranking may consider factors such as relevance to your query, popularity, and project
                         activity. The ranking logic can evolve over time as the platform improves.
                     </p>
+
+                    <h4 id='oss-health'>How is the OSS Health score calculated?</h4>
+                    <div>
+                        <p>
+                            The OSS Health score is a number from <b>0 to 100</b> that estimates how actively and
+                            sustainably a project is maintained on GitHub, based on its activity over the
+                            last <b>12 weeks</b>. It combines four signals, each scored from 0 to 1:
+                        </p>
+
+                        <ul>
+                            <li>
+                                <b>Commit consistency (30%)</b> — how regular the commit activity is from week to week.
+                            </li>
+                            <li>
+                                <b>Issue responsiveness (25%)</b> — what share of issues get closed, and how quickly.
+                            </li>
+                            <li>
+                                <b>Pull request management (25%)</b> — what share of pull requests get merged, and how
+                                quickly.
+                            </li>
+                            <li>
+                                <b>Author diversity (20%)</b> — how many people contribute, and how evenly the work is
+                                spread across them (the &quot;bus factor&quot;).
+                            </li>
+                        </ul>
+
+                        <p>
+                            The signals are combined with a weighted sum:
+                            <br/>
+                            <code>OSS Health = 100 × (0.30·C + 0.25·I + 0.25·P + 0.20·A)</code>
+                        </p>
+
+                        <p>
+                            When a project doesn&apos;t have enough recent activity to compute one of the signals, the
+                            score is shown as &quot;—&quot; rather than a potentially misleading number. The methodology
+                            is inspired by academic work on <a href={REPOSITORY_STABILITY_PAPER_URL} target="_blank"
+                            className={"link-secondary"}>repository stability</a>.
+                        </p>
+                    </div>
 
                     <h4>Are there any licensing or usage considerations when using libraries listed on klibs.io?</h4>
                     <p>

--- a/frontend/src/app/ui/project-info/index.tsx
+++ b/frontend/src/app/ui/project-info/index.tsx
@@ -6,6 +6,32 @@ import cn from "classnames";
 import styles from "./styles.module.css";
 import FeaturedLabel from "@/app/ui/featured-label";
 import {trackEvent, GAEvent} from "@/app/analytics";
+import {Tooltip, TooltipPlacement} from "@rescui/tooltip";
+import {InfoOutlineIcon} from "@rescui/icons";
+
+const DEPENDENTS_HINT = "The number of other libraries in the klibs.io catalog that depend on this project.";
+const OSS_HEALTH_HINT = "A 0–100 score of how actively the project is maintained on GitHub.";
+
+function MetricLabel(
+    {label, hint, learnMoreHref, placement = "top"}:
+    {label: string; hint: string; learnMoreHref?: string; placement?: TooltipPlacement}
+) {
+    const content = learnMoreHref ? (
+        <>
+            {hint}{" "}
+            <Link href={learnMoreHref} className="link-secondary">How it&apos;s calculated</Link>
+        </>
+    ) : hint;
+
+    return (
+        <span className={styles.metricLabel}>
+            {label}
+            <Tooltip placement={placement} content={content}>
+                <InfoOutlineIcon className={styles.metricLabelIcon} size="s" tabIndex={0} aria-label={`${label}: ${hint}`}/>
+            </Tooltip>
+        </span>
+    );
+}
 
 export function ProjectInfo({projectOverview}: {projectOverview: ProjectDetails}) {
     // Owner link for metadata while it is not in a separate component
@@ -41,13 +67,13 @@ export function ProjectInfo({projectOverview}: {projectOverview: ProjectDetails}
 
                 {/*Dependents*/}
                 <div>
-                    <span>Dependents</span>
+                    <MetricLabel label="Dependents" hint={DEPENDENTS_HINT}/>
                     <span className={styles.dataValue}>{projectOverview && projectOverview.dependentCount}</span>
                 </div>
 
                 {/*OSS Health*/}
                 <div>
-                    <span>OSS Health</span>
+                    <MetricLabel label="OSS Health" hint={OSS_HEALTH_HINT} learnMoreHref="/faq#oss-health" placement="bottom"/>
                     <span className={styles.dataValue}>
                         {projectOverview && projectOverview.ossHealthScore !== null ? projectOverview.ossHealthScore : '—'}
                     </span>

--- a/frontend/src/app/ui/project-info/styles.module.css
+++ b/frontend/src/app/ui/project-info/styles.module.css
@@ -27,6 +27,24 @@
     color: black;
 }
 
+.metricLabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.metricLabelIcon {
+    color: var(--rs-color-icon-secondary, #9b9b9b);
+    cursor: help;
+    flex-shrink: 0;
+    outline: none;
+}
+
+.metricLabelIcon:hover,
+.metricLabelIcon:focus-visible {
+    color: var(--rs-color-icon, currentColor);
+}
+
 .linkWrapper {
     display: flex;
     gap: 8px;


### PR DESCRIPTION
## Top 10 by stars

| Repo | CV | C old→new | P old→new | I | A | Health old→new | Δ | stored |
|---|---:|---|---|---:|---:|---|---:|---:|
| okhttp | 0.96 | 0.04 → 0.68 | 1.00 → 1.00 | 0.94 | 0.75 | 65 → 84 | +19 | 69 |
| compose-multiplatform | 0.98 | 0.02 → 0.67 | 1.00 → 1.00 | 0.94 | 0.90 | 67 → 87 | +20 | 72 |
| ktor | 0.55 | 0.45 → 0.82 | 0.90 → 0.95 | 0.50 | 0.85 | 65 → 78 | +13 | 66 |
| ag-ui | 0.67 | 0.33 → 0.78 | 1.00 → 1.00 | 0.50 | 0.84 | 64 → 78 | +14 | 64 |
| kotlinx.coroutines | 1.09 | 0.00 → 0.64 | 0.50 → 0.50 | 0.50 | 0.80 | 41 → 60 | +19 | 47 |
| coil | 0.64 | 0.36 → 0.79 | 1.00 → 1.00 | 0.94 | 0.57 | 71 → 84 | +13 | 73 |
| runanywhere-sdks | 1.63 | 0.00 → 0.46 | 1.00 → 1.00 | 0.50 | 0.80 | 54 → 67 | +13 | 53 |
| koin | 1.17 | 0.00 → 0.61 | 0.21 → 0.21 | 0.50 | 0.26 | 23 → 41 | +18 | 22 |
| okio | 0.83 | 0.17 → 0.72 | 1.00 → 1.00 | 0.56 | 0.60 | 56 → 73 | +17 | 54 |
| sqldelight | 0.93 | 0.07 → 0.69 | 1.00 → 1.00 | 0.74 | 0.80 | 62 → 80 | +18 | 61 |

## Top 10 by dependent_count

| Repo | CV | C old→new | P old→new | I | A | Health old→new | Δ | stored |
|---|---:|---|---|---:|---:|---|---:|---:|
| compose-multiplatform | 0.98 | 0.02 → 0.67 | 1.00 → 1.00 | 0.94 | 0.90 | 67 → 87 | +20 | 72 |
| ktor | 0.55 | 0.45 → 0.82 | 0.90 → 0.95 | 0.50 | 0.85 | 65 → 78 | +13 | 66 |
| kotlinx.coroutines | 1.09 | 0.00 → 0.64 | 0.50 → 0.50 | 0.50 | 0.80 | 41 → 60 | +19 | 47 |
| koin | 1.17 | 0.00 → 0.61 | 0.21 → 0.21 | 0.50 | 0.26 | 23 → 41 | +18 | 22 |
| okio | 0.83 | 0.17 → 0.72 | 1.00 → 1.00 | 0.56 | 0.60 | 56 → 73 | +17 | 54 |
| kotlinx.serialization | 1.63 | 0.00 → 0.46 | 0.55 → 0.78 | 0.50 | 0.89 | 44 → 63 | +19 | 43 |
| kotlinx-datetime | 1.02 | 0.00 → 0.66 | 0.50 → 0.50 | 0.50 | 0.70 | 39 → 59 | +20 | 43 |
| kotlinx-io | 3.32 | 0.00 → 0.00 | 0.25 → 0.50 | 0.80 | 0.12 | 29 → 35 | +6 | 28 |
| kotlinx-atomicfu | 1.44 | 0.00 → 0.52 | 0.95 → 0.97 | 0.00 | 0.30 | 30 → 46 | +16 | 29 |
| Kermit | 2.24 | 0.00 → 0.25 | 0.50 → 0.60 | 0.50 | 0.63 | 38 → 48 | +10 | 37 |

## 10 random

| Repo | CV | C old→new | P old→new | I | A | Health old→new | Δ | stored |
|---|---:|---|---|---:|---:|---|---:|---:|
| vico | 0.51 | 0.49 → 0.83 | 1.00 → 1.00 | 1.00 | 0.88 | 82 → 93 | +11 | 79 |
| markdown | 2.06 | 0.00 → 0.31 | 1.00 → 1.00 | 0.00 | 0.56 | 36 → 46 | +10 | 36 |
| colorpicker-compose | 2.22 | 0.00 → 0.26 | 0.95 → 0.97 | 0.00 | 0.58 | 35 → 44 | +9 | 35 |
| compass | 1.58 | 0.00 → 0.47 | 0.50 → 0.50 | 0.00 | 0.47 | 22 → 36 | +14 | 21 |
| svg-to-compose | 1.03 | 0.00 → 0.66 | 1.00 → 1.00 | 0.79 | 0.76 | 60 → 79 | +19 | 64 |
| Keval | 3.32 | 0.00 → 0.00 | 1.00 → 1.00 | 0.50 | 0.39 | 45 → 45 | +0 | 45 |
| powersync-kotlin | 1.08 | 0.00 → 0.64 | 1.00 → 1.00 | 0.90 | 0.70 | 62 → 81 | +19 | 70 |
| 2p-kt | 0.75 | 0.25 → 0.75 | 1.00 → 1.00 | 0.00 | 0.12 | 35 → 50 | +15 | 27 |
| Grant | 1.44 | 0.00 → 0.52 | 1.00 → 1.00 | 0.99 | 0.28 | 55 → 71 | +16 | 55 |
| okta-mobile-kotlin | 0.96 | 0.04 → 0.68 | 0.50 → 0.70 | 0.00 | 0.12 | 16 → 40 | +24 | 18 |