### PR TITLE
KTL-4519 GitHub repositories on klibs.io doesn't update properly

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/config/BackoffConfig.kt
+++ b/app/src/main/kotlin/io/klibs/app/config/BackoffConfig.kt
@@ -15,11 +15,6 @@ class BackoffConfig {
         BackoffProvider("SyncGitHubOwner", meterRegistry)
 
     @Bean
-    @Qualifier("repoBackoffProvider")
-    fun repoBackoffProvider(meterRegistry: MeterRegistry): BackoffProvider =
-        BackoffProvider("SyncGitHubRepository", meterRegistry)
-
-    @Bean
     @Qualifier("aiDescriptionBackoffProvider")
     fun aiDescriptionBackoffProvider(meterRegistry: MeterRegistry): BackoffProvider =
         BackoffProvider("AiProjectDescription", meterRegistry)

--- a/app/src/main/kotlin/io/klibs/app/job/GitHubRepositoryUpdatingJob.kt
+++ b/app/src/main/kotlin/io/klibs/app/job/GitHubRepositoryUpdatingJob.kt
@@ -4,9 +4,9 @@ import io.klibs.app.indexing.GitHubIndexingService
 import io.klibs.app.util.BackoffProvider
 import io.klibs.core.scm.repository.ScmRepositoryEntity
 import io.klibs.core.scm.repository.ScmRepositoryRepository
+import io.klibs.core.scm.repository.ScmRepositorySchedulingRepository
 import io.klibs.core.scm.repository.health.OssHealthIssueOrPrSyncService
 import io.klibs.core.scm.repository.health.OssHealthScoreService
-import org.springframework.beans.factory.annotation.Qualifier
 import net.javacrumbs.shedlock.core.LockAssert
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.beans.factory.annotation.Value
@@ -32,13 +32,12 @@ class GitHubRepositoryUpdatingJob(val gitHubRepositoryUpdatingService: GitHubRep
 @Service
 class GitHubRepositoryUpdatingService(
     private val scmRepositoryRepository: ScmRepositoryRepository,
+    private val schedulingRepository: ScmRepositorySchedulingRepository,
     private val githubIndexingService: GitHubIndexingService,
     private val ossHealthIssueOrPrSyncService: OssHealthIssueOrPrSyncService,
     private val ossHealthScoreService: OssHealthScoreService,
     @Value("\${klibs.integration.github.update-repos-per-iteration:3}")
-    private val reposUpdatedPerCall: Int,
-    @Qualifier("repoBackoffProvider")
-    private val repoBackoffProvider: BackoffProvider,
+    private val reposUpdatedPerCall: Int
 ) {
 
     fun syncRepositoryWithGitHub() {
@@ -48,15 +47,17 @@ class GitHubRepositoryUpdatingService(
         }
         reposToUpdate.forEach { repoToUpdate ->
             try {
-                if (repoBackoffProvider.isBackedOff(repoToUpdate.idNotNull)) {
-                    logger.debug("Selected repoId=${repoToUpdate.id} ${repoToUpdate.ownerLogin}/${repoToUpdate.name} is in backoff; skipping this run")
-                    return@forEach
-                }
                 githubIndexingService.updateRepo(repoToUpdate)
-                repoBackoffProvider.onSuccess(repoToUpdate.idNotNull)
+                schedulingRepository.clearSchedule(repoToUpdate.idNotNull)
             } catch (e: Exception) {
                 logger.error("Error while updating a repo", e)
-                repoBackoffProvider.onFailure(repoToUpdate.idNotNull)
+                val attempts = (schedulingRepository.find(repoToUpdate.idNotNull)?.retryAttempts ?: 0) + 1
+                val backoffDelay = BackoffProvider.computeBackoffDelay(
+                    base = 60L,
+                    exp = 3L,
+                    attempts = attempts
+                )
+                schedulingRepository.scheduleNextRetry(repoToUpdate.idNotNull, attempts, backoffDelay.seconds)
                 return@forEach
             }
 

--- a/app/src/main/kotlin/io/klibs/app/job/PackageVersionTypeJob.kt
+++ b/app/src/main/kotlin/io/klibs/app/job/PackageVersionTypeJob.kt
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
 @Component
+@ConditionalOnProperty(
+    value = ["klibs.scheduling.fill-version-type.enabled"],
+    havingValue = "true",
+)
 class PackageVersionTypeJob(private val packageService: PackageService) {
 
     private val logger = LoggerFactory.getLogger(PackageVersionTypeJob::class.java)

--- a/app/src/main/kotlin/io/klibs/app/job/RefreshDependentCountJob.kt
+++ b/app/src/main/kotlin/io/klibs/app/job/RefreshDependentCountJob.kt
@@ -5,11 +5,13 @@ import io.micrometer.core.annotation.Timed
 import net.javacrumbs.shedlock.core.LockAssert
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
 @Component
+@ConditionalOnProperty("klibs.indexing", havingValue = "true")
 class RefreshDependentCountJob(
     private val projectRepository: ProjectRepository,
 ) {

--- a/app/src/main/kotlin/io/klibs/app/util/BackoffProvider.kt
+++ b/app/src/main/kotlin/io/klibs/app/util/BackoffProvider.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.pow
 
 class BackoffProvider(
     private val jobName: String,
@@ -34,7 +35,7 @@ class BackoffProvider(
     fun onFailure(id: Int, now: Instant = Instant.now()) {
         val previous = backoffStates[id]
         val attempts = (previous?.attempts ?: 0) + 1
-        val delay = computeBackoffDelay(attempts)
+        val delay = computeBackoffDelay(attempts = attempts)
         val nextAllowedAt = now.plus(delay)
         backoffStates[id] = BackoffState(attempts, nextAllowedAt)
         logger.warn("Job $jobName: Backoff for id=$id attempts=$attempts nextAllowedAt=$nextAllowedAt delay=${delay.toSeconds()}s")
@@ -44,16 +45,14 @@ class BackoffProvider(
         backoffStates.remove(id)
     }
 
-    private fun computeBackoffDelay(attempts: Int): Duration {
-        // Base 60s, exponential factor 2, capped at 1 hour
-        val base = 60L
-        val exp = 1L shl (attempts - 1).coerceAtMost(10) // cap growth
-        val seconds = (base * exp).coerceAtMost(3600L)
-        return Duration.ofSeconds(seconds)
-    }
-
     companion object {
         private val logger = LoggerFactory.getLogger(BackoffProvider::class.java)
         const val METRIC_NAME = "klibs.backoff.states.size"
+
+        fun computeBackoffDelay(base: Long = 60L, exp: Long = 2L, attempts: Int): Duration {
+            val exp = exp.toDouble().pow(attempts - 1).toLong()
+            val seconds = (base * exp).coerceAtMost(60 * 60 * 24 * 30L) // 1 month
+            return Duration.ofSeconds(seconds)
+        }
     }
 }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -78,6 +78,8 @@ klibs:
   scheduling:
     process-indexing-queue:
       enabled: ${PROCESS_INDEXING_QUEUE_ENABLED:true}
+    fill-version-type:
+      enabled: ${FILL_VERSION_TYPE_ENABLED:true}
   indexing-configuration:
     executor:
       thread-count: 2

--- a/app/src/main/resources/db/migration/2026-Q2/2026-06-02_create_scm_repo_scheduling_table.yml
+++ b/app/src/main/resources/db/migration/2026-Q2/2026-06-02_create_scm_repo_scheduling_table.yml
@@ -1,0 +1,37 @@
+databaseChangeLog:
+  - changeSet:
+      id: create scm_repo_scheduling table
+      author: nikita.vlaev@jetbrains.com
+      comment: "KTL-4519: per-repo update backoff state, moved out of scm_repo into its own table so failing repos don't occupy every update slot. Absence of a row = eligible now (row deleted on success, upserted on failure)."
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: scm_repo_scheduling
+      changes:
+        - createTable:
+            tableName: scm_repo_scheduling
+            columns:
+              - column:
+                  name: scm_repo_id
+                  type: INTEGER
+                  constraints:
+                    nullable: false
+                    references: scm_repo(id)
+                    foreignKeyName: fk_scm_repo_scheduling_scm_repo_id
+                    deleteCascade: true
+              - column:
+                  name: next_retry_at
+                  type: TIMESTAMP
+                  remarks: "When this repo may next be selected for update. Set on update failure; the row is deleted on success."
+              - column:
+                  name: retry_attempts
+                  type: INTEGER
+                  defaultValueNumeric: 0
+                  remarks: "Consecutive failed update attempts. Used to determine backoff duration before retrying."
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: scm_repo_scheduling
+            columnNames: scm_repo_id
+            constraintName: pk_scm_repo_scheduling

--- a/app/src/main/resources/db/migration/db.changelog-master.yml
+++ b/app/src/main/resources/db/migration/db.changelog-master.yml
@@ -167,4 +167,6 @@ databaseChangeLog:
       file: db/migration/2026-Q2/2026-04-24_oss_health_metric.yml
   - include:
       file: db/migration/2026-Q2/2026-04-30_recreate_project_index_with_health_score.yml
+  - include:
+      file: db/migration/2026-Q2/2026-06-02_create_scm_repo_scheduling_table.yml
 

--- a/app/src/test/kotlin/io/klibs/app/job/GitHubRepositoryUpdatingServiceTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/job/GitHubRepositoryUpdatingServiceTest.kt
@@ -1,10 +1,10 @@
 package io.klibs.app.job
 
 import io.klibs.app.indexing.GitHubIndexingService
-import io.klibs.app.util.BackoffProvider
 import io.klibs.core.owner.ScmOwnerType
 import io.klibs.core.scm.repository.ScmRepositoryEntity
 import io.klibs.core.scm.repository.ScmRepositoryRepository
+import io.klibs.core.scm.repository.ScmRepositorySchedulingRepository
 import io.klibs.core.scm.repository.health.OssHealthIssueOrPrSyncService
 import io.klibs.core.scm.repository.health.OssHealthScoreService
 import org.junit.jupiter.api.Test
@@ -24,31 +24,31 @@ import java.time.Instant
 class GitHubRepositoryUpdatingServiceTest {
 
     private val scmRepositoryRepository: ScmRepositoryRepository = mock()
+    private val schedulingRepository: ScmRepositorySchedulingRepository = mock()
     private val githubIndexingService: GitHubIndexingService = mock()
     private val ossHealthIssueOrPrSyncService: OssHealthIssueOrPrSyncService = mock()
     private val ossHealthScoreService: OssHealthScoreService = mock()
-    private val backoff: BackoffProvider = mock()
 
     private val uut = GitHubRepositoryUpdatingService(
         scmRepositoryRepository = scmRepositoryRepository,
+        schedulingRepository = schedulingRepository,
         githubIndexingService = githubIndexingService,
         ossHealthIssueOrPrSyncService = ossHealthIssueOrPrSyncService,
         ossHealthScoreService = ossHealthScoreService,
         reposUpdatedPerCall = 3,
-        repoBackoffProvider = backoff,
     )
 
     @Test
     fun `skips both OSS sub-steps when neither is due`() {
         val repo = repo(id = 1)
         whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(repo))
-        whenever(backoff.isBackedOff(eq(repo.idNotNull), any())).thenReturn(false)
         whenever(ossHealthIssueOrPrSyncService.isDue(eq(repo), any())).thenReturn(false)
         whenever(ossHealthScoreService.isDue(eq(repo), any())).thenReturn(false)
 
         uut.syncRepositoryWithGitHub()
 
         verify(githubIndexingService).updateRepo(repo)
+        verify(schedulingRepository).clearSchedule(repo.idNotNull)
         verify(ossHealthIssueOrPrSyncService, never()).syncOne(any(), any())
         verify(ossHealthScoreService, never()).computeOne(any(), any())
     }
@@ -57,7 +57,6 @@ class GitHubRepositoryUpdatingServiceTest {
     fun `runs both OSS sub-steps when both are due`() {
         val repo = repo(id = 1)
         whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(repo))
-        whenever(backoff.isBackedOff(eq(repo.idNotNull), any())).thenReturn(false)
         whenever(ossHealthIssueOrPrSyncService.isDue(eq(repo), any())).thenReturn(true)
         whenever(ossHealthScoreService.isDue(eq(repo), any())).thenReturn(true)
 
@@ -69,15 +68,15 @@ class GitHubRepositoryUpdatingServiceTest {
     }
 
     @Test
-    fun `skips both OSS sub-steps when updateRepo throws`() {
+    fun `records failure and skips both OSS sub-steps when updateRepo throws`() {
         val repo = repo(id = 1)
         whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(repo))
-        whenever(backoff.isBackedOff(eq(repo.idNotNull), any())).thenReturn(false)
         whenever(githubIndexingService.updateRepo(repo)).thenThrow(RuntimeException("boom"))
 
         uut.syncRepositoryWithGitHub()
 
-        verify(backoff).onFailure(eq(repo.idNotNull), any())
+        verify(schedulingRepository).scheduleNextRetry(eq(repo.idNotNull), any(), any())
+        verify(schedulingRepository, never()).clearSchedule(any())
         verify(ossHealthIssueOrPrSyncService, never()).isDue(any(), any())
         verify(ossHealthScoreService, never()).isDue(any(), any())
     }
@@ -86,7 +85,6 @@ class GitHubRepositoryUpdatingServiceTest {
     fun `score sub-step still runs when issue-or-pr sync throws`() {
         val repo = repo(id = 1)
         whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(repo))
-        whenever(backoff.isBackedOff(eq(repo.idNotNull), any())).thenReturn(false)
         whenever(ossHealthIssueOrPrSyncService.isDue(eq(repo), any())).thenReturn(true)
         whenever(ossHealthScoreService.isDue(eq(repo), any())).thenReturn(true)
         whenever(ossHealthIssueOrPrSyncService.syncOne(eq(repo), any())).thenThrow(RuntimeException("sync boom"))
@@ -101,7 +99,6 @@ class GitHubRepositoryUpdatingServiceTest {
         val r1 = repo(id = 1)
         val r2 = repo(id = 2)
         whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(r1, r2))
-        whenever(backoff.isBackedOff(any(), any())).thenReturn(false)
         whenever(ossHealthScoreService.isDue(eq(r1), any())).thenReturn(true)
         whenever(ossHealthScoreService.isDue(eq(r2), any())).thenReturn(false)
         whenever(ossHealthIssueOrPrSyncService.isDue(any(), any())).thenReturn(false)
@@ -114,16 +111,14 @@ class GitHubRepositoryUpdatingServiceTest {
     }
 
     @Test
-    fun `OSS sub-steps are skipped when repo is in backoff`() {
-        val repo = repo(id = 1)
-        whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(listOf(repo))
-        whenever(backoff.isBackedOff(eq(repo.idNotNull), any())).thenReturn(true)
+    fun `does nothing when no repo is selected for update`() {
+        whenever(scmRepositoryRepository.findMultipleForUpdate(any())).thenReturn(emptyList())
 
         uut.syncRepositoryWithGitHub()
 
         verify(githubIndexingService, never()).updateRepo(any())
-        verify(ossHealthIssueOrPrSyncService, never()).isDue(any(), any())
-        verify(ossHealthScoreService, never()).isDue(any(), any())
+        verify(schedulingRepository, never()).clearSchedule(any())
+        verify(schedulingRepository, never()).scheduleNextRetry(any(), any(), any())
     }
 
     private fun repo(id: Int) = ScmRepositoryEntity(

--- a/app/src/test/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepositoryDbTest.kt
+++ b/app/src/test/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepositoryDbTest.kt
@@ -1,0 +1,53 @@
+package io.klibs.core.scm.repository
+
+import BaseUnitWithDbLayerTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [ScmRepositoryRepository.findMultipleForUpdate] and the per-repo backoff
+ * helpers against a Testcontainer Postgres. Seeds repos A–F (see seed-repos.sql); eligible ones,
+ * highest-star first, are D(60), A(50), B(30), F(20). C is in an active backoff window and E was
+ * updated within 24h.
+ */
+class ScmRepositoryRepositoryDbTest : BaseUnitWithDbLayerTest() {
+
+    @Autowired
+    private lateinit var repo: ScmRepositoryRepository
+
+    @Autowired
+    private lateinit var scheduling: ScmRepositorySchedulingRepository
+
+    @Test
+    @Sql("classpath:sql/ScmRepositoryRepositoryDbTest/seed-repos.sql")
+    fun `findMultipleForUpdate skips backed-off and fresh repos, ordered by stars desc`() {
+        val ids = repo.findMultipleForUpdate(10).map { it.idNotNull }
+
+        assertEquals(listOf(800013, 800010, 800011, 800015), ids) // D, A, B, F by stars desc
+    }
+
+    @Test
+    @Sql("classpath:sql/ScmRepositoryRepositoryDbTest/seed-repos.sql")
+    fun `scheduleNextRetry backs the repo off out of the next selection`() {
+        assertTrue(repo.findMultipleForUpdate(10).any { it.idNotNull == 800010 })
+
+        scheduling.scheduleNextRetry(800010, attempts = 1, backoffDelaySeconds = 3600) // next_retry_at an hour ahead
+
+        assertFalse(repo.findMultipleForUpdate(10).any { it.idNotNull == 800010 })
+    }
+
+    @Test
+    @Sql("classpath:sql/ScmRepositoryRepositoryDbTest/seed-repos.sql")
+    fun `clearSchedule clears backoff so a backed-off repo is selectable again`() {
+        // C (800012) is in an active backoff window (next_retry_at in the future).
+        assertFalse(repo.findMultipleForUpdate(10).any { it.idNotNull == 800012 })
+
+        scheduling.clearSchedule(800012) // removes the scheduling row
+
+        assertTrue(repo.findMultipleForUpdate(10).any { it.idNotNull == 800012 })
+    }
+}

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -4,6 +4,8 @@ klibs:
   scheduling:
     process-indexing-queue:
       enabled: false
+    fill-version-type:
+      enabled: false
 
 spring:
   sql:

--- a/app/src/test/resources/sql/ScmRepositoryRepositoryDbTest/seed-repos.sql
+++ b/app/src/test/resources/sql/ScmRepositoryRepositoryDbTest/seed-repos.sql
@@ -1,0 +1,52 @@
+-- One owner + several repos exercising findMultipleForUpdate's eligibility filter.
+-- Expected eligible (stale > 24h, no active backoff window), highest-star first: D, A, B, F.
+INSERT INTO public.scm_owner (
+    id, id_native, followers, updated_at,
+    login, type, name, description,
+    homepage, twitter_handle, email, location, company
+) VALUES (
+    800001, 800000001, 0, current_timestamp,
+    'retry-test', 'organization', 'Retry Test', NULL,
+    NULL, NULL, NULL, NULL, NULL
+);
+
+INSERT INTO public.scm_repo (
+    id_native, id, owner_id,
+    has_gh_pages, has_issues, has_wiki, has_readme,
+    created_ts, updated_at, last_activity_ts,
+    stars, open_issues,
+    name, description, homepage,
+    license_key, license_name, default_branch
+) VALUES
+    -- A: eligible, 50 stars
+    (800000010, 800010, 800001, false, true, false, false,
+     current_timestamp, current_timestamp - interval '2 days', current_timestamp,
+     50, 0, 'repo-a', NULL, NULL, NULL, NULL, 'main'),
+    -- B: eligible, 30 stars
+    (800000011, 800011, 800001, false, true, false, false,
+     current_timestamp, current_timestamp - interval '2 days', current_timestamp,
+     30, 0, 'repo-b', NULL, NULL, NULL, NULL, 'main'),
+    -- C: excluded — active backoff window (see scm_repo_scheduling below)
+    (800000012, 800012, 800001, false, true, false, false,
+     current_timestamp, current_timestamp - interval '2 days', current_timestamp,
+     40, 0, 'repo-c', NULL, NULL, NULL, NULL, 'main'),
+    -- D: eligible, 60 stars — no scheduling row
+    (800000013, 800013, 800001, false, true, false, false,
+     current_timestamp, current_timestamp - interval '2 days', current_timestamp,
+     60, 0, 'repo-d', NULL, NULL, NULL, NULL, 'main'),
+    -- E: excluded — updated within the last 24h
+    (800000014, 800014, 800001, false, true, false, false,
+     current_timestamp, current_timestamp, current_timestamp,
+     100, 0, 'repo-e', NULL, NULL, NULL, NULL, 'main'),
+    -- F: eligible — backoff window already elapsed (see scm_repo_scheduling below)
+    (800000015, 800015, 800001, false, true, false, false,
+     current_timestamp, current_timestamp - interval '2 days', current_timestamp,
+     20, 0, 'repo-f', NULL, NULL, NULL, NULL, 'main');
+
+-- Scheduling state lives in its own table now; a row exists only while a repo is backed off.
+-- C: next retry still in the future -> excluded.  F: window already elapsed -> eligible.
+INSERT INTO public.scm_repo_scheduling (
+    scm_repo_id, next_retry_at, retry_attempts
+) VALUES
+    (800012, current_timestamp + interval '1 hour', 2),
+    (800015, current_timestamp - interval '1 hour', 3);

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryEntity.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryEntity.kt
@@ -52,7 +52,17 @@ data class ScmRepositoryEntity(
     val openIssues: Int?,
 
     val lastActivityTs: Instant,
-    val updatedAtTs: Instant
+    val updatedAtTs: Instant,
 ) {
     val idNotNull: Int get() = requireNotNull(id)
 }
+
+/**
+ * Per-repo update backoff state, stored in `scm_repo_scheduling` (one row per repo, only while backed off).
+ * Absence of a row means the repo is eligible for update now.
+ */
+data class ScmRepositorySchedulingData(
+    val scmRepoId: Int,
+    val nextRetryAt: Instant? = null,
+    val retryAttempts: Int = 0
+)

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepository.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepository.kt
@@ -18,6 +18,10 @@ interface ScmRepositoryRepository {
 
     fun findIdByName(ownerLogin: String, name: String): Int?
 
+    /**
+     * Next [limit] repos due for a GitHub refresh, highest-star first.
+     * Skips repos still within their backoff window (see `scm_repo_scheduling.next_retry_at`).
+     */
     fun findMultipleForUpdate(limit: Int = 3): List<ScmRepositoryEntity>
 }
 

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepositoryJdbc.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositoryRepositoryJdbc.kt
@@ -297,9 +297,11 @@ class ScmRepositoryRepositoryJdbc(
                    repo.updated_at
             FROM scm_repo repo
                      JOIN scm_owner owner ON repo.owner_id = owner.id
+                     LEFT JOIN scm_repo_scheduling sched ON sched.scm_repo_id = repo.id
             WHERE repo.updated_at < (current_timestamp - interval '24 hours')
+              AND (sched.next_retry_at IS NULL OR sched.next_retry_at < current_timestamp)
             ORDER BY repo.stars DESC
-            LIMIT :limit FOR UPDATE
+            LIMIT :limit FOR UPDATE OF repo
                 SKIP LOCKED
         """.trimIndent()
 

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositorySchedulingRepository.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositorySchedulingRepository.kt
@@ -1,0 +1,23 @@
+package io.klibs.core.scm.repository
+
+/**
+ * Persistence for per-repo update backoff state (`scm_repo_scheduling`).
+ *
+ * A row exists only while a repo is backed off after a failed update; its absence means the repo is
+ * eligible now. The backoff *policy* (how long to wait for a given attempt count) lives in the app
+ * layer — this interface only reads and writes the state.
+ */
+interface ScmRepositorySchedulingRepository {
+
+    /** Current scheduling state for a repo, or `null` if it has none (i.e. eligible now). */
+    fun find(scmRepoId: Int): ScmRepositorySchedulingData?
+
+    /** Clears backoff state after a successful update by removing the row, so the repo is eligible again. */
+    fun clearSchedule(scmRepoId: Int)
+
+    /**
+     * Records a failed update: stores the new [attempts] count and pushes the next eligible time
+     * [backoffDelaySeconds] into the future. Upserts, since the first failure has no existing row.
+     */
+    fun scheduleNextRetry(scmRepoId: Int, attempts: Int, backoffDelaySeconds: Long)
+}

--- a/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositorySchedulingRepositoryJdbc.kt
+++ b/core/scm-repository/src/main/kotlin/io/klibs/core/scm/repository/ScmRepositorySchedulingRepositoryJdbc.kt
@@ -1,0 +1,58 @@
+package io.klibs.core.scm.repository
+
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class ScmRepositorySchedulingRepositoryJdbc(
+    private val jdbcClient: JdbcClient
+) : ScmRepositorySchedulingRepository {
+
+    override fun find(scmRepoId: Int): ScmRepositorySchedulingData? {
+        val sql = """
+            SELECT scm_repo_id, next_retry_at, retry_attempts
+            FROM scm_repo_scheduling
+            WHERE scm_repo_id = :scmRepoId
+        """.trimIndent()
+
+        return jdbcClient.sql(sql)
+            .param("scmRepoId", scmRepoId)
+            .query(ROW_MAPPER)
+            .optional()
+            .getOrNull()
+    }
+
+    override fun clearSchedule(scmRepoId: Int) {
+        jdbcClient.sql("DELETE FROM scm_repo_scheduling WHERE scm_repo_id = :scmRepoId")
+            .param("scmRepoId", scmRepoId)
+            .update()
+    }
+
+    override fun scheduleNextRetry(scmRepoId: Int, attempts: Int, backoffDelaySeconds: Long) {
+        val sql = """
+            INSERT INTO scm_repo_scheduling (scm_repo_id, next_retry_at, retry_attempts)
+            VALUES (:scmRepoId, current_timestamp + (:backoffDelay * interval '1 second'), :attempts)
+            ON CONFLICT (scm_repo_id) DO UPDATE
+                SET next_retry_at  = current_timestamp + (:backoffDelay * interval '1 second'),
+                    retry_attempts = :attempts
+        """.trimIndent()
+
+        jdbcClient.sql(sql)
+            .param("scmRepoId", scmRepoId)
+            .param("backoffDelay", backoffDelaySeconds)
+            .param("attempts", attempts)
+            .update()
+    }
+
+    private companion object {
+        private val ROW_MAPPER = RowMapper<ScmRepositorySchedulingData> { rs, _ ->
+            ScmRepositorySchedulingData(
+                scmRepoId = rs.getInt("scm_repo_id"),
+                nextRetryAt = rs.getTimestamp("next_retry_at")?.toInstant(),
+                retryAttempts = rs.getInt("retry_attempts")
+            )
+        }
+    }
+}


### PR DESCRIPTION
Moved scm_repo backoff mechanism to table.

No need to touch other job's backoff mechanisms, selection strategy there allows us to avoid stagnating on 3 poisoned items.
The proper solution would be present once we introduce queues.