### PR TITLE
KTL-4226 Improve downloading Maven Index

### DIFF
--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenIndexDownloadingService.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenIndexDownloadingService.kt
@@ -51,6 +51,7 @@ class MavenIndexDownloadingService(
                 val updateRequest = IndexUpdateRequest(context, resourceFetcher)
                 updateRequest.isForceFullUpdate = true
                 updateRequest.indexTempDir = indexingContextManager.getIndexTmpDir()
+                updateRequest.localIndexCacheDir = indexingContextManager.getLocalIndexCacheDir()
 
                 val result = indexUpdater.fetchAndUpdateIndex(updateRequest)
 

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenIndexingContextManager.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenIndexingContextManager.kt
@@ -34,6 +34,8 @@ class MavenIndexingContextManager(
 
     fun getIndexTmpDir(): File = File("${properties.central.indexDir}/tmp")
 
+    fun getLocalIndexCacheDir(): File = File("${properties.central.indexDir}/local-index-cache")
+
     private fun createCentralContext(contextId: String): IndexingContext {
         if (!indexDir.exists()) {
             indexDir.mkdirs()

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/index/MavenIndexDownloadingServiceTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/index/MavenIndexDownloadingServiceTest.kt
@@ -107,6 +107,9 @@ class MavenIndexDownloadingServiceTest {
             whenever(responseSpec.hint(any<String>(), any())).thenReturn(responseSpec)
             whenever(responseSpec.body<String>()).thenReturn(props)
 
+            val localIndexCacheDir = File(tempDir, "local-index-cache")
+            whenever(indexingContextManager.getLocalIndexCacheDir()).thenReturn(localIndexCacheDir)
+
             whenever(indexUpdateResult.isFullUpdate).thenReturn(true)
             whenever(indexUpdater.fetchAndUpdateIndex(any())).thenReturn(indexUpdateResult)
 
@@ -115,6 +118,7 @@ class MavenIndexDownloadingServiceTest {
             verify(indexUpdater).fetchAndUpdateIndex(check {
                 assertTrue(it.isForceFullUpdate, "Should have forceFullUpdate flag set to true")
                 assertEquals(indexingContext.indexDirectoryFile, it.indexTempDir, "Should use context index directory as temp dir")
+                assertEquals(localIndexCacheDir, it.localIndexCacheDir, "Should use local index cache dir to decouple download from extraction")
             })
         }
     }


### PR DESCRIPTION
Setting `updateRequest.localIndexCacheDir` should make the `indexUpdater.fetchAndUpdateIndex(updateRequest)` first save the zip in provided directory and only later extract it