### PR TITLE
fix(ktl-4296): navigation to join slack improved

### DIFF
--- a/frontend/src/app/faq/page.tsx
+++ b/frontend/src/app/faq/page.tsx
@@ -6,6 +6,7 @@ import R3 from "@/app/img/kodee/r3.svg";
 
 import Image from "next/image";
 import Link from "next/link";
+import {SlackIcon} from "@rescui/icons";
 import Container from "@/app/ui/container";
 import {textCn} from "@rescui/typography";
 import styles from "./styles.module.css";
@@ -174,8 +175,8 @@ export default function Faq() {
                         href={'https://github.com/JetBrains/klibs-io/issues/new/choose'}>GitHub issue tracker</a>.
                     </p>
 
-                    <h4>
-                        Join the community discussion
+                    <h4 id="slack-guide" className={styles.slackGuide}>
+                        Join the community discussion <SlackIcon className={styles.slackIcon}/>
                     </h4>
                     <p>
                         If you are a member of Kotlin public Slack, <Link target="_blank"

--- a/frontend/src/app/faq/styles.module.css
+++ b/frontend/src/app/faq/styles.module.css
@@ -63,6 +63,25 @@
     z-index: 4;
 }
 
+.slackIcon {
+    color: var(--b70);
+}
+
+.slackGuide:target,
+.slackGuide:target + p {
+    border-radius: 6px;
+    animation: slackHighlight 2.5s ease-out;
+}
+
+@keyframes slackHighlight {
+    0%, 25% {
+        background-color: rgba(127, 82, 255, 0.25);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 @keyframes kodeeMove {
     0%   {
         transform: rotate(0deg) translateX(0px)

--- a/frontend/src/app/ui/navbar/index.tsx
+++ b/frontend/src/app/ui/navbar/index.tsx
@@ -178,6 +178,7 @@ export default function Navbar() {
                                 href="/faq#slack-guide"
                                 data-testid="slack-link"
                                 className={cn(textCn('rs-link', {mode: 'clear'}), styles.navItem, styles.navIcon, "hide-on-small")}
+                                title="Join Slack channel"
                                 onClick={() => trackEvent(GAEvent.SLACK_CLICK, {})}
                             >
                                 <SlackIcon/>


### PR DESCRIPTION
* added id to the "Join the community discussion" so the anchor links work
* added a small background transition to highlight the needed section
* also added the slack icon to the "Join the community discussion" also to highlight where to look

<img width="1248" height="1452" alt="Monosnap screencast 2026-07-21 15-19-45" src="https://github.com/user-attachments/assets/46275068-6753-4ab4-85dc-9a2e2887d64d" />
<img width="1217" height="1416" alt="Monosnap screencast 12026-07-21 15-19-45" src="https://github.com/user-attachments/assets/2c62952d-8a34-499b-8577-366edab5e20a" />
<img width="2082" height="1381" alt="Monosnap screencast 2026-07-21 15-24-57" src="https://github.com/user-attachments/assets/71ad636e-34fc-493a-b2c8-5363c6d03475" />
