### PR TITLE
KTL-4617: spike - detect potential malicious package pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,11 @@ cache
 localstack-data
 
 .junie/memory
+
+### DB dumps
+*.dump
+*.sql.gz
+*.dump.gz
+tmp_db_sync/
+db-dumps/
 /.output.txt

--- a/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.sql
+++ b/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.sql
@@ -1,28 +1,7 @@
--- KTL-4617 — potential malicious package pairs.
--- =============================================================================
 -- Primary signal (KTL-4617): SAME project + SAME artifactId + DIFFERENT groupId.
--- Within one indexed project a library name (artifactId) should map to a single
--- publisher coordinate (groupId). When the same name appears under two or more
--- groupIds, one branch may be a typo-/name-squat or impersonation (e.g. a hostile
--- actor republishing a popular library under a look-alike groupId).
---
--- Secondary clues (KTL-4618) are carried in the same row so a reviewer can rank
--- branches without a second query:
---   * release_rank        — 1 = earliest first-publish = presumed ORIGINAL; a
---                           higher rank branch was published LATER (the ticket's
---                           main "malicious is usually released later" criterion).
---   * days_after_original — days between this branch's first publish and the
---                           earliest branch in the pair.
---   * versions            — squats tend to have very few releases.
---   * scm_url             — a mismatched/missing repo across branches is a red flag.
---   * has_generated_description — whether our AI wrote the description (weak clue).
---
--- Plain (non-materialized) VIEW: always live, no refresh job, no index. Release
--- dates come straight from `package` (min/max release_ts per branch), so the
--- first-publish date used for ranking is authoritative rather than the
--- latest-version date exposed by package_index.
---
+-- Secondary clues (KTL-4618) are carried in the same row
 -- One row per BRANCH (project_id, artifact_id, group_id) of a conflicting pair.
+
 CREATE OR REPLACE VIEW malicious_package_pair AS
 WITH conflicting AS (SELECT project_id, artifact_id
                      FROM package

--- a/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.sql
+++ b/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.sql
@@ -1,0 +1,69 @@
+-- KTL-4617 — potential malicious package pairs.
+-- =============================================================================
+-- Primary signal (KTL-4617): SAME project + SAME artifactId + DIFFERENT groupId.
+-- Within one indexed project a library name (artifactId) should map to a single
+-- publisher coordinate (groupId). When the same name appears under two or more
+-- groupIds, one branch may be a typo-/name-squat or impersonation (e.g. a hostile
+-- actor republishing a popular library under a look-alike groupId).
+--
+-- Secondary clues (KTL-4618) are carried in the same row so a reviewer can rank
+-- branches without a second query:
+--   * release_rank        — 1 = earliest first-publish = presumed ORIGINAL; a
+--                           higher rank branch was published LATER (the ticket's
+--                           main "malicious is usually released later" criterion).
+--   * days_after_original — days between this branch's first publish and the
+--                           earliest branch in the pair.
+--   * versions            — squats tend to have very few releases.
+--   * scm_url             — a mismatched/missing repo across branches is a red flag.
+--   * has_generated_description — whether our AI wrote the description (weak clue).
+--
+-- Plain (non-materialized) VIEW: always live, no refresh job, no index. Release
+-- dates come straight from `package` (min/max release_ts per branch), so the
+-- first-publish date used for ranking is authoritative rather than the
+-- latest-version date exposed by package_index.
+--
+-- One row per BRANCH (project_id, artifact_id, group_id) of a conflicting pair.
+CREATE OR REPLACE VIEW malicious_package_pair AS
+WITH conflicting AS (SELECT project_id, artifact_id
+                     FROM package
+                     WHERE project_id IS NOT NULL
+                     GROUP BY project_id, artifact_id
+                     HAVING count(DISTINCT group_id) > 1),
+     branch AS (SELECT p.project_id,
+                       p.artifact_id,
+                       p.group_id,
+                       count(*)                                             AS versions,
+                       (array_agg(p.version ORDER BY p.release_ts DESC))[1] AS latest_version,
+                       min(p.release_ts)                                    AS first_release_ts,
+                       max(p.release_ts)                                    AS latest_release_ts,
+                       (array_agg(p.scm_url ORDER BY p.release_ts DESC)
+                            FILTER (WHERE p.scm_url IS NOT NULL))[1]         AS scm_url,
+                       bool_or(p.generated_description)                     AS has_generated_description
+                FROM package p
+                         JOIN conflicting c
+                              ON c.project_id = p.project_id AND c.artifact_id = p.artifact_id
+                GROUP BY p.project_id, p.artifact_id, p.group_id)
+SELECT b.project_id,
+       proj.name                                             AS project_name,
+       owner.login                                           AS owner_login,
+       owner.type                                            AS owner_type,
+       repo.name                                             AS repo_name,
+       b.artifact_id,
+       b.group_id,
+       b.versions,
+       b.latest_version,
+       b.first_release_ts,
+       b.latest_release_ts,
+       b.scm_url,
+       b.has_generated_description,
+       count(*) OVER w                                        AS branch_count,
+       array_agg(b.group_id) OVER w                           AS group_ids,
+       rank() OVER (PARTITION BY b.project_id, b.artifact_id ORDER BY b.first_release_ts)
+                                                              AS release_rank,
+       (EXTRACT(EPOCH FROM (b.first_release_ts - min(b.first_release_ts) OVER w)) / 86400)::int
+                                                              AS days_after_original
+FROM branch b
+         JOIN project proj    ON proj.id = b.project_id
+         JOIN scm_owner owner ON owner.id = proj.owner_id
+         LEFT JOIN scm_repo repo ON repo.id = proj.scm_repo_id
+WINDOW w AS (PARTITION BY b.project_id, b.artifact_id);

--- a/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.yml
+++ b/app/src/main/resources/db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: create malicious_package_pair view (KTL-4617)
+      author: daniel.emeka-ilozor@jetbrains.com
+      changes:
+        - sqlFile:
+            path: 2026-07-12_create_malicious_package_pair_view.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sql:
+            sql: DROP VIEW IF EXISTS malicious_package_pair;

--- a/app/src/main/resources/db/migration/db.changelog-master.yml
+++ b/app/src/main/resources/db/migration/db.changelog-master.yml
@@ -169,4 +169,6 @@ databaseChangeLog:
       file: db/migration/2026-Q2/2026-04-30_recreate_project_index_with_health_score.yml
   - include:
       file: db/migration/2026-Q2/2026-06-02_create_scm_repo_scheduling_table.yml
+  - include:
+      file: db/migration/2026-Q3/2026-07-12_create_malicious_package_pair_view.yml
 

--- a/scripts/sql/ktl-4617_malicious_package_pairs.sql
+++ b/scripts/sql/ktl-4617_malicious_package_pairs.sql
@@ -1,0 +1,113 @@
+-- KTL-4617 — Detect potential malicious pairs of packages
+-- =========================================================
+-- Main signal: SAME project + SAME artifactId + DIFFERENT groupId.
+-- Two artifacts that resolve to the same library name within one project but
+-- publish under different Maven groupIds are a strong indicator of typo-/name-
+-- squatting or impersonation (a hostile actor republishing a popular library
+-- under a look-alike groupId).
+--
+-- This is a READ-ONLY analysis script (no schema changes). Run it against a
+-- database populated with real data (e.g. a prod copy — see
+-- scripts/copy_prod_db_to_local.sh); the local seed DB usually has no pairs.
+--
+-- Usage:
+--   docker exec -e PGPASSWORD=klibs klibs-postgres \
+--     psql -U klibs -d klibs -f - < scripts/sql/ktl-4617_malicious_package_pairs.sql
+-- or (against any DB):
+--   psql "$DATABASE_URL" -f scripts/sql/ktl-4617_malicious_package_pairs.sql
+--
+-- Produces three result sets:
+--   1. Summary   — one row per suspicious (project, artifactId) with all groupIds
+--   2. Detail    — one row per groupId branch, with versions/timestamps/metadata
+--   3. Watchlist — flagged groupIds cross-checked against the banned_packages table
+
+\pset pager off
+\timing off
+
+-- The set of (project, artifactId) coordinates that carry more than one groupId.
+-- Reused by every section below.
+\set flagged_cte 'flagged AS (SELECT project_id, artifact_id FROM package WHERE project_id IS NOT NULL GROUP BY project_id, artifact_id HAVING count(DISTINCT group_id) > 1)'
+
+
+\echo '==========================================================================='
+\echo ' 1) SUMMARY — suspicious (project, artifactId) pairs, most groupIds first'
+\echo '==========================================================================='
+
+SELECT p.project_id,
+       proj.name                                            AS project_name,
+       owner.login                                          AS owner_login,
+       owner.type                                           AS owner_type,
+       repo.name                                            AS repo_name,
+       p.artifact_id,
+       count(DISTINCT p.group_id)                           AS distinct_group_ids,
+       array_agg(DISTINCT p.group_id ORDER BY p.group_id)   AS group_ids,
+       count(*)                                             AS package_rows
+FROM package p
+         JOIN project proj    ON proj.id = p.project_id
+         JOIN scm_owner owner ON owner.id = proj.owner_id
+         LEFT JOIN scm_repo repo ON repo.id = proj.scm_repo_id
+WHERE p.project_id IS NOT NULL
+GROUP BY p.project_id, proj.name, owner.login, owner.type, repo.name, p.artifact_id
+HAVING count(DISTINCT p.group_id) > 1
+ORDER BY distinct_group_ids DESC, owner.login, p.artifact_id;
+
+
+\echo ''
+\echo '==========================================================================='
+\echo ' 2) DETAIL — per-groupId breakdown for each suspicious pair'
+\echo '     (compare release windows / version counts to spot the impostor branch)'
+\echo '==========================================================================='
+
+WITH flagged AS (SELECT project_id, artifact_id
+                 FROM package
+                 WHERE project_id IS NOT NULL
+                 GROUP BY project_id, artifact_id
+                 HAVING count(DISTINCT group_id) > 1),
+     latest AS (SELECT DISTINCT ON (project_id, artifact_id, group_id)
+                    project_id, artifact_id, group_id, version AS latest_version, release_ts AS latest_release_ts
+                FROM package
+                ORDER BY project_id, artifact_id, group_id, release_ts DESC)
+SELECT p.project_id,
+       proj.name                                    AS project_name,
+       owner.login                                  AS owner_login,
+       p.artifact_id,
+       p.group_id,
+       count(*)                                     AS versions,
+       l.latest_version,
+       min(p.release_ts)                            AS first_release_ts,
+       l.latest_release_ts,
+       max(p.scm_url)                               AS scm_url,
+       bool_or(p.generated_description)             AS has_generated_description
+FROM package p
+         JOIN flagged f      ON f.project_id = p.project_id AND f.artifact_id = p.artifact_id
+         JOIN project proj   ON proj.id = p.project_id
+         JOIN scm_owner owner ON owner.id = proj.owner_id
+         JOIN latest l       ON l.project_id = p.project_id
+                                    AND l.artifact_id = p.artifact_id
+                                    AND l.group_id = p.group_id
+GROUP BY p.project_id, proj.name, owner.login, p.artifact_id, p.group_id,
+         l.latest_version, l.latest_release_ts
+ORDER BY p.project_id, p.artifact_id, first_release_ts;
+
+
+\echo ''
+\echo '==========================================================================='
+\echo ' 3) WATCHLIST — flagged groupIds already present in banned_packages'
+\echo '==========================================================================='
+
+WITH flagged AS (SELECT project_id, artifact_id
+                 FROM package
+                 WHERE project_id IS NOT NULL
+                 GROUP BY project_id, artifact_id
+                 HAVING count(DISTINCT group_id) > 1)
+SELECT DISTINCT p.project_id,
+                p.artifact_id,
+                p.group_id,
+                (bp.id IS NOT NULL) AS already_banned,
+                bp.reason           AS ban_reason
+FROM package p
+         JOIN flagged f ON f.project_id = p.project_id AND f.artifact_id = p.artifact_id
+         LEFT JOIN banned_packages bp
+                   ON bp.group_id = p.group_id
+                       AND (bp.artifact_id IS NULL OR bp.artifact_id = p.artifact_id)
+ORDER BY already_banned DESC, p.project_id, p.artifact_id, p.group_id;

--- a/scripts/sql/ktl-4617_malicious_package_pairs.sql
+++ b/scripts/sql/ktl-4617_malicious_package_pairs.sql
@@ -1,20 +1,4 @@
--- KTL-4617 — Detect potential malicious pairs of packages
--- =========================================================
--- Main signal: SAME project + SAME artifactId + DIFFERENT groupId.
--- Two artifacts that resolve to the same library name within one project but
--- publish under different Maven groupIds are a strong indicator of typo-/name-
--- squatting or impersonation (a hostile actor republishing a popular library
--- under a look-alike groupId).
---
--- This is a READ-ONLY analysis script (no schema changes). Run it against a
--- database populated with real data (e.g. a prod copy — see
--- scripts/copy_prod_db_to_local.sh); the local seed DB usually has no pairs.
---
--- Usage:
---   docker exec -e PGPASSWORD=klibs klibs-postgres \
---     psql -U klibs -d klibs -f - < scripts/sql/ktl-4617_malicious_package_pairs.sql
--- or (against any DB):
---   psql "$DATABASE_URL" -f scripts/sql/ktl-4617_malicious_package_pairs.sql
+-- This is a READ-ONLY analysis script.
 --
 -- Produces three result sets:
 --   1. Summary   — one row per suspicious (project, artifactId) with all groupIds
@@ -24,8 +8,6 @@
 \pset pager off
 \timing off
 
--- The set of (project, artifactId) coordinates that carry more than one groupId.
--- Reused by every section below.
 \set flagged_cte 'flagged AS (SELECT project_id, artifact_id FROM package WHERE project_id IS NOT NULL GROUP BY project_id, artifact_id HAVING count(DISTINCT group_id) > 1)'
 
 


### PR DESCRIPTION
Detected pairs with same `artifactId` but different `groupId` under the same project.
Added sql script to detect this, and updated to include liquibase malicious_package_pair view.

Findings: 1,034 pairs across 219 projects.