### PR TITLE
KTL-4226: Increased default ephemeral storage from 25Gi to 40Gi

### DIFF
--- a/values.base.yaml
+++ b/values.base.yaml
@@ -26,7 +26,7 @@ extraVolumes:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 25Gi
+              storage: 40Gi
 extraVolumeMounts:
   - name: data
     mountPath: /data


### PR DESCRIPTION
New of downloading Maven Cetral index algorithm requires more memory as it works in 3 steps: 
1) Downloads Maven Central index as a zip ~ 3Gi
2) Unpacks it ~ 11Gi
3) Prepares a woking copy of index ~ 11Gi
That is why we exeeded the limit.