### PR TITLE
KTL-4887: stop the package indexing queue on a 429

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
@@ -19,6 +19,7 @@ import io.klibs.core.scm.repository.ScmRepositoryEntity
 import io.klibs.integration.ai.PackageDescriptionGenerator
 import io.klibs.integration.maven.MavenArtifact
 import io.klibs.integration.maven.MavenPom
+import io.klibs.integration.maven.MavenRateLimitedException
 import io.klibs.integration.maven.MavenStaticDataProvider
 import io.klibs.integration.maven.delegate.KotlinToolingMetadataDelegate
 import kotlinx.coroutines.Dispatchers
@@ -102,7 +103,7 @@ class PackageIndexingService(
      * Claims and processes the highest-priority pending index request, marking it FAILED
      * (incrementing its retry counter) on error.
      *
-     * @return true if a request was processed, false if the queue is empty.
+     * @return true if a request was processed, false if the queue is empty or we are rate limited.
      */
     fun processPackageQueue(): Boolean {
         val indexRequest = indexingRequestRepository.findFirstForIndexing()
@@ -111,29 +112,41 @@ class PackageIndexingService(
             return false
         }
         val requestId = indexRequest.idNotNull
-        var succeeded = false
+        var outcome = Outcome.FAILED
         var errorMessage: String? = null
         try {
             selfProvider.getObject().processRequest(requestId)
-            succeeded = true
+            outcome = Outcome.SUCCESS
+        } catch (e: MavenRateLimitedException) {
+            outcome = Outcome.RATE_LIMITED
+            logger.warn("Stopping the indexing queue, request id=$requestId stays pending: ${e.message}")
         } catch (e: Exception) {
             errorMessage = e.message
             logger.error("Error during claiming an indexing request: ${e.message}", e)
         } finally {
             try {
-                if (succeeded) {
-                    userRequestReportWriter.saveSuccessReport(requestId)
-                    indexingRequestRepository.deleteById(requestId)
-                } else {
-                    indexingRequestRepository.markAsFailed(requestId, errorMessage)
-                    userRequestReportWriter.saveFailureReportIfTerminal(requestId, errorMessage)
+                when (outcome) {
+                    Outcome.SUCCESS -> {
+                        userRequestReportWriter.saveSuccessReport(requestId)
+                        indexingRequestRepository.deleteById(requestId)
+                    }
+
+                    Outcome.FAILED -> {
+                        indexingRequestRepository.markAsFailed(requestId, errorMessage)
+                        userRequestReportWriter.saveFailureReportIfTerminal(requestId, errorMessage)
+                    }
+
+                    // Leave the request untouched so a rate limit does not burn a retry attempt.
+                    Outcome.RATE_LIMITED -> Unit
                 }
             } catch (ex: Exception) {
                 logger.error("Error during finalizing index request with id=$requestId: ${ex.message}", ex)
             }
         }
-        return true
+        return outcome != Outcome.RATE_LIMITED
     }
+
+    private enum class Outcome { SUCCESS, FAILED, RATE_LIMITED }
 
     @Transactional
     internal fun processRequest(idToProcess: Long) {

--- a/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
@@ -18,6 +18,7 @@ import io.klibs.integration.github.model.GitHubRepository
 import io.klibs.integration.github.model.GitHubUser
 import io.klibs.integration.github.model.ReadmeFetchResult
 import io.klibs.integration.maven.MavenPom
+import io.klibs.integration.maven.MavenRateLimitedException
 import io.klibs.integration.maven.PomWithReleaseDate
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.androidx.GradleMetadata
@@ -118,6 +119,27 @@ class PackageIndexingServiceTest : BaseUnitWithDbLayerTest() {
         )
         assertEquals(1, failedAttempts, "Failed attempts should be incremented")
         assertContains(output.out, "Mocked getPom exception")
+    }
+
+    @Test
+    @Sql(scripts = ["classpath:sql/PackageIndexingServiceTest/insert-request-for-processing.sql"])
+    fun `a 429 from Maven Central stops the queue and keeps the request pending`() {
+        val requestBeforeProcessing = indexingRequestRepository.findFirstForIndexing()
+        assertNotNull(requestBeforeProcessing)
+
+        whenever(mavenStaticDataProvider.getPomWithReleaseDate(any()))
+            .thenThrow(MavenRateLimitedException("https://repo1.maven.org/maven2/x/y/1.0.0/y-1.0.0.pom"))
+
+        val result = uut.processPackageQueue()
+
+        assertFalse(result, "Should stop draining the queue while the egress IP is rate limited")
+
+        val row = jdbcTemplate.queryForMap(
+            "SELECT status, failed_attempts FROM package_index_request WHERE id = ${requestBeforeProcessing.idNotNull}"
+        )
+        assertEquals("PENDING", row["status"], "Request should stay pending")
+        assertEquals(0, (row["failed_attempts"] as Number).toInt(), "Rate limiting should not burn a retry attempt")
+        assertNotNull(indexingRequestRepository.findFirstForIndexing(), "Request must be eligible for the next run")
     }
 
     @Test

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/MavenRateLimitedException.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/MavenRateLimitedException.kt
@@ -1,0 +1,3 @@
+package io.klibs.integration.maven
+
+class MavenRateLimitedException(url: String) : RuntimeException("Rate limited by Maven Central on $url")

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/scraper/impl/CentralSonatypeScraper.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/scraper/impl/CentralSonatypeScraper.kt
@@ -1,6 +1,7 @@
 package io.klibs.integration.maven.scraper.impl
 
 import io.klibs.integration.maven.MavenArtifact
+import io.klibs.integration.maven.MavenRateLimitedException
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.scraper.MavenCentralScraper
 import io.klibs.integration.maven.search.MavenSearchClient
@@ -69,7 +70,7 @@ class CentralSonatypeScraper(
         errorChannel: Channel<Exception>
     ): Flow<MavenArtifact> = flow {
         for ((coordinates, knownVersions) in knownArtifacts) {
-            runCatching {
+            val exception = runCatching {
                 val parts = coordinates.split(":")
                 if (parts.size != 2) return@runCatching
                 val groupId = parts[0]
@@ -92,10 +93,14 @@ class CentralSonatypeScraper(
                         )
                     }
                 }
-            }.onFailure { exception ->
-                errorChannel.send(
-                    Exception("Could not process request for metadata of $coordinates", exception)
-                )
+            }.exceptionOrNull() ?: continue
+
+            errorChannel.send(
+                Exception("Could not process request for metadata of $coordinates", exception)
+            )
+            if (exception is MavenRateLimitedException) {
+                logger.warn("Rate limited by Maven Central, stopping new version discovery")
+                break
             }
         }
     }

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClient.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/search/impl/BaseMavenSearchClient.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import io.klibs.integration.maven.MavenArtifact
 import io.klibs.integration.maven.dto.MavenMetadata
 import io.klibs.integration.maven.MavenPom
+import io.klibs.integration.maven.MavenRateLimitedException
 import io.klibs.integration.maven.MavenStaticDataProvider
 import io.klibs.integration.maven.PomWithReleaseDate
 import io.klibs.integration.maven.androidx.GradleMetadata
@@ -30,6 +31,7 @@ import java.time.format.DateTimeFormatter
 
 private const val DEFAULT_PAGE_SIZE = 200
 internal const val MAX_REDIRECTS = 3
+private const val HTTP_TOO_MANY_REQUESTS = 429 // not in HttpURLConnection constants
 
 abstract class BaseMavenSearchClient(
     private val xmlMapper: XmlMapper,
@@ -193,6 +195,8 @@ abstract class BaseMavenSearchClient(
                         }
                         followRedirects(location, headers, converter, redirectCount + 1, requestExecutor)
                     }
+
+                    HTTP_TOO_MANY_REQUESTS -> throw MavenRateLimitedException(serviceUri)
 
                     else -> throw IOException("Unexpected response: ${response.code}")
                 }

--- a/scripts/kubernetes/apply-prod-dump-on-klibs-features-environment-job.yaml
+++ b/scripts/kubernetes/apply-prod-dump-on-klibs-features-environment-job.yaml
@@ -20,22 +20,22 @@ spec:
               /bin/psql-restore
           envFrom:
             - secretRef: # db secret
-                name: standalone-db-secrets # secret to database admin user. Important: it should be admin for pg
+                name: db-secrets # secret to database admin user. Important: it should be admin for pg
             - secretRef: # bucket secret
                 name: db-backup-admin-secret # secret to bucket with ReadOnly/ReadWrite permissions
           env:
             - name: BACKUP_FILE # prefix in the bucket for a backup file
               value: backups/mydatabase/klibs_prod_db_latest_version.pgdump.gz
             - name: PGHOST
-              valueFrom: { secretKeyRef: { name: standalone-db-secrets, key: host } }
+              valueFrom: { secretKeyRef: { name: db-secrets, key: host } }
             - name: PGPORT
-              valueFrom: { secretKeyRef: { name: standalone-db-secrets, key: port } }
+              valueFrom: { secretKeyRef: { name: db-secrets, key: port } }
             - name: PGUSER
-              valueFrom: { secretKeyRef: { name: standalone-db-secrets, key: username } }
+              valueFrom: { secretKeyRef: { name: db-secrets, key: username } }
             - name: PGPASSWORD
-              valueFrom: { secretKeyRef: { name: standalone-db-secrets, key: password } }
+              valueFrom: { secretKeyRef: { name: db-secrets, key: password } }
             - name: PGDATABASE
-              valueFrom: { secretKeyRef: { name: standalone-db-secrets, key: name } }
+              valueFrom: { secretKeyRef: { name: db-secrets, key: name } }
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -43,7 +43,7 @@ profiles:
       - op: replace
         path: /deploy/helm/releases/0/valuesFiles/1
         value: values.stage.yaml
-  - name: feature
+  - name: features
     patches:
       - op: replace
         path: /build/artifacts/0/image


### PR DESCRIPTION
The idea is to stop queue to not overload maven central with 429.
That way we will wait 4h until the next job run and will not push MC to increase the backoff period (which they do increase if we spam after 429).