### PR TITLE
Add frontend AGENTS.md guideline

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+Next.js 14 (App Router) frontend for klibs.io. React 18 + TypeScript, JetBrains `@rescui/*` design system.
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env.local   # NEXT_PUBLIC_API_URL points at the backend
+```
+
+## Commands
+
+```bash
+npm run dev                  # dev server on :3000
+npm run build                # production build — run before claiming a change is done
+npm run lint                 # ESLint (next/core-web-vitals + next/typescript); also a pre-commit hook
+npm run test:component       # Vitest + React Testing Library (jsdom)
+npm run test:visual          # UI Verify visual tests in real Chromium (needs npm run pw:install once)
+npm run test:e2e             # Playwright user journeys (needs a running frontend)
+```
+
+## Structure
+
+- `src/app/` — App Router routes; each route folder holds `page.tsx` and a `*-page-content.tsx` client part.
+- `src/app/ui/<kebab-case>/` — one component per folder: `index.tsx` + `styles.module.css` + colocated tests.
+- `src/app/api.ts` — all backend `fetch` calls, typed by `src/app/types.ts`. Add new calls here, not in components.
+- `src/app/{types,helpers,constants,hooks,media,analytics}.ts` — shared primitives.
+- `src/test/` — Vitest setup and fixtures. `e2e-tests/` — Playwright specs.
+
+## Conventions
+
+- Import via the `@/*` alias (`@/app/ui/container`), never deep relative paths.
+- Server Components by default; add `'use client'` only for state, effects, or event handlers.
+- Styling: CSS Modules (`styles.module.css`) composed with `classnames`; typography via `textCn` from `@rescui/typography`. No inline styles, no new CSS frameworks.
+- Prefer existing `@rescui/*` and `@jetbrains/kotlin-web-site-ui` components over hand-rolled UI. Avoid adding dependencies.
+- 4-space indent, 120-char lines, default export for components.
+- Client-visible env vars must be prefixed `NEXT_PUBLIC_` and added to `.env.example`.
+
+## Testing
+
+Pick the cheapest level that proves the behavior:
+
+- `*.test.tsx` — rendering, links, keyboard, filters. Assert user-visible outcomes via Testing Library queries; don't assert implementation details or call order.
+- `*.visual.test.tsx` — layout and styling regressions only. Runs as a separate Vitest project, so `test:component` skips it. Import the global CSS the component needs, pin an explicit viewport, and disable animations/transitions so frames are deterministic.
+- `e2e-tests/*` — reserve for full journeys crossing routing or backend boundaries.
+
+## Guardrails
+
+- Never push; never delete branches.
+- Keep diffs minimal and localized. No drive-by refactors, renames, or reformatting.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -47,5 +47,6 @@ Pick the cheapest level that proves the behavior:
 
 ## Guardrails
 
-- Never push; never delete branches.
+- Never delete branches.
+- Never push to the main branch.
 - Keep diffs minimal and localized. No drive-by refactors, renames, or reformatting.


### PR DESCRIPTION
## Summary

Fills in the empty `frontend/AGENTS.md` placeholder with a short agent guideline for the Next.js frontend, following current AGENTS.md conventions (concise, imperative, only what an agent can't infer from the code).

## Contents

- **Setup / Commands** — the scripts an agent actually needs, with non-obvious caveats inline: `pw:install` before visual tests, `test:e2e` needs a running frontend, `lint` also runs as a husky pre-commit hook.
- **Structure** — the `page.tsx` / `*-page-content.tsx` split, one-folder-per-component `ui/` layout, and that `src/app/api.ts` is the single place for backend fetches.
- **Conventions** — `@/*` alias, Server Components by default (only 16 of 84 `.tsx` files are `'use client'`), CSS Modules + `classnames` + `textCn`, prefer existing `@rescui` components, avoid new dependencies.
- **Testing** — the three-tier choice, including that the visual project is excluded from `test:component`, plus the determinism requirements (global CSS imports, explicit viewport, animations disabled).
- **Guardrails** — never delete branches, never push to the main branch, keep diffs minimal.

Everything was verified against the actual code and configs rather than copied from the README. Notably, the README's `npm run format` step is deliberately omitted — that script doesn't exist in `package.json`, so documenting it would send an agent down a dead end.

## Base

Targets `ktl-4936-uiverify-setup` rather than `release`/`master` so the diff is exactly this one file. The branch it was cut from also carries the 17-commit test revamp, which is out of scope here.

## Test plan

Documentation only — no runtime code touched, so no test run applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)