### PR TITLE
KTL-2087: Track non-KMP artifacts during package indexing

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
@@ -13,6 +13,7 @@ import io.klibs.core.pckg.enums.VersionType
 import io.klibs.core.pckg.repository.IndexingRequestRepository
 import io.klibs.core.pckg.repository.PackageRepository
 import io.klibs.core.pckg.service.MavenArtifactService
+import io.klibs.core.pckg.service.NonKmpPackageService
 import io.klibs.core.pckg.service.PackageService
 import io.klibs.core.project.ProjectEntity
 import io.klibs.core.scm.repository.ScmRepositoryEntity
@@ -54,6 +55,7 @@ class PackageIndexingService(
     private val packageService: PackageService,
     private val packageRepository: PackageRepository,
     private val mavenArtifactService: MavenArtifactService,
+    private val nonKmpPackageService: NonKmpPackageService,
     private val indexingConfigurationProperties: IndexingConfigurationProperties,
     private val selfProvider: ObjectProvider<PackageIndexingService>
 ) {
@@ -82,8 +84,7 @@ class PackageIndexingService(
                                     if (newArtifacts.isNotEmpty()) {
                                         val indexRequests = newArtifacts.map { it.toIndexRequest() }
                                         val insertedRequests = indexingRequestRepository.saveAll(indexRequests).count()
-                                        val removedRepeating = indexingRequestRepository.removeRepeating()
-                                        logger.debug("Queued up ${insertedRequests - removedRepeating} newArtifacts")
+                                        logger.debug("Queued up $insertedRequests newArtifacts")
                                     }
                                 }
                         }
@@ -189,9 +190,21 @@ class PackageIndexingService(
             )
         }
 
+        val mavenCoordinates = MavenCoordinatesDTO(pom.groupId, pom.artifactId, pom.version)
+
         logger.trace("Getting tooling metadata for {}", mavenArtifact)
         val toolingMetadata = provider.getKotlinToolingMetadata(mavenArtifact)
-            ?: error("Unable to find tooling metadata for $mavenArtifact")
+        if (toolingMetadata == null) {
+            logger.debug("Unable to find tooling metadata for {}, classifying it as non-KMP", mavenArtifact)
+            val mavenArtifactDto = mavenArtifactService.resolveOrCreate(mavenCoordinates)
+            nonKmpPackageService.save(
+                mavenArtifact = mavenArtifactDto,
+                releaseTs = requireNotNull(mavenArtifact.releasedAt) { "releasedAt is null for $mavenArtifact" },
+                repo = mavenArtifact.scraperType,
+                scmUrl = pom.scm?.url?.let { normalizeGitHubLink(it) },
+            )
+            return
+        }
 
         logger.trace("Persisting the package for {}", indexRequest)
         val packageDto = constructPackage(mavenArtifact, pom, toolingMetadata, project, indexRequest.reindex)
@@ -200,9 +213,7 @@ class PackageIndexingService(
                 ?: error("Unable to update a non-existing artifact: $mavenArtifact")
             updated.id
         } else {
-            val mavenArtifactDto = mavenArtifactService.resolveOrCreate(
-                MavenCoordinatesDTO(pom.groupId, pom.artifactId, pom.version)
-            )
+            val mavenArtifactDto = mavenArtifactService.resolveOrCreate(mavenCoordinates)
             packageRepository.save(packageDto.toEntity(mavenArtifactDto)).id
         }
 

--- a/app/src/main/kotlin/io/klibs/app/indexing/PomIndexingService.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/PomIndexingService.kt
@@ -40,7 +40,7 @@ class PomIndexingService(
     }
 
     fun extractDevelopers(pom: MavenPom): List<PackageDeveloper> {
-        val developers = pom.developers ?: return emptyList()
+        val developers = pom.developers
         return developers.mapNotNull { dev ->
             val name = (dev.name ?: dev.organization)
                 ?.takeIf { it.isNotBlank() }
@@ -54,7 +54,7 @@ class PomIndexingService(
     }
 
     fun extractLicenses(pom: MavenPom): List<PackageLicense> {
-        val licenses = pom.licenses ?: return emptyList()
+        val licenses = pom.licenses
         return licenses.mapNotNull { license ->
             val name = license.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
             PackageLicense(
@@ -89,7 +89,7 @@ class PomIndexingService(
 
     private fun MavenPom.extractDependencies(): Set<MavenCoordinatesDTO> =
         dependencies
-            ?.asSequence()
+            .asSequence()
             ?.mapNotNull { dep ->
                 val group = dep.groupId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                 val artifact = dep.artifactId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null

--- a/app/src/main/kotlin/io/klibs/app/service/impl/CentralSonatypeUserIndexingRequestService.kt
+++ b/app/src/main/kotlin/io/klibs/app/service/impl/CentralSonatypeUserIndexingRequestService.kt
@@ -1,6 +1,5 @@
 package io.klibs.app.service.impl
 
-import io.klibs.app.configuration.properties.IndexingConfigurationProperties
 import io.klibs.app.exceptions.UserRequestProcessingException
 import io.klibs.app.service.UserIndexingRequestService
 import io.klibs.app.util.toIndexRequest
@@ -14,7 +13,6 @@ import io.klibs.integration.maven.service.impl.SonatypeCentralStaticDataProvider
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/app/src/main/resources/db/migration/2026-Q3/2026-09-04_create_non_kmp_packages.yml
+++ b/app/src/main/resources/db/migration/2026-Q3/2026-09-04_create_non_kmp_packages.yml
@@ -1,0 +1,124 @@
+databaseChangeLog:
+  - changeSet:
+      id: create non_kmp_packages table
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            tableExists:
+              tableName: non_kmp_packages
+      changes:
+        - createTable:
+            tableName: non_kmp_packages
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_non_kmp_packages
+              - column:
+                  name: maven_artifact_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: release_ts
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scraper_type
+                  type: TEXT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: scm_url
+                  type: TEXT
+
+  - changeSet:
+      id: add unique index on non_kmp_packages maven_artifact_id
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            indexExists:
+              tableName: non_kmp_packages
+              indexName: uindex_non_kmp_packages_maven_artifact_id
+      changes:
+        - createIndex:
+            tableName: non_kmp_packages
+            indexName: uindex_non_kmp_packages_maven_artifact_id
+            unique: true
+            columns:
+              - column:
+                  name: maven_artifact_id
+
+  - changeSet:
+      id: create non_kmp_packages sequence
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            sequenceExists:
+              sequenceName: non_kmp_packages_id_seq
+      changes:
+        - sql:
+            sql: |
+              CREATE SEQUENCE non_kmp_packages_id_seq
+                  AS BIGINT
+                  INCREMENT BY 50
+                  START WITH 1;
+
+  - changeSet:
+      id: add non_kmp_packages.maven_artifact_id foreign key
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            foreignKeyConstraintExists:
+              foreignKeyName: fk_non_kmp_packages_maven_artifact_id
+      changes:
+        - addForeignKeyConstraint:
+            constraintName: fk_non_kmp_packages_maven_artifact_id
+            baseTableName: non_kmp_packages
+            baseColumnNames: maven_artifact_id
+            referencedTableName: maven_artifact
+            referencedColumnNames: id
+
+  - changeSet:
+      id: reset tooling metadata package index request failures
+      author: dmitrii.krasnov@jetbrains.com
+      preConditions:
+        - onFail: MARK_RAN
+        - tableExists:
+            tableName: package_index_request
+        - columnExists:
+            tableName: package_index_request
+            columnName: status
+        - columnExists:
+            tableName: package_index_request
+            columnName: failed_attempts
+        - columnExists:
+            tableName: package_index_request
+            columnName: failed_ts
+        - columnExists:
+            tableName: package_index_request
+            columnName: last_error_message
+      changes:
+        - sql:
+            sql: |
+              UPDATE package_index_request
+              SET status = 'PENDING',
+                  failed_attempts = 0,
+                  failed_ts = NULL,
+                  last_error_message = NULL,
+                  scraper_type = 'GOOGLE_MAVEN_CENTRAL_MIRROR'
+              WHERE last_error_message LIKE 'Unable to find tooling metadata for %';

--- a/app/src/main/resources/db/migration/db.changelog-master.yml
+++ b/app/src/main/resources/db/migration/db.changelog-master.yml
@@ -185,3 +185,5 @@ databaseChangeLog:
       file: db/migration/2026-Q3/2026-09-03_add_project_visibility.yml
   - include:
       file: db/migration/2026-Q3/2026-09-03_indices_exclude_hidden_projects.yml
+  - include:
+      file: db/migration/2026-Q3/2026-09-04_create_non_kmp_packages.yml

--- a/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
@@ -6,6 +6,7 @@ import io.klibs.core.pckg.entity.IndexingRequestEntity
 import io.klibs.core.pckg.entity.UserRequestIssueEntity
 import io.klibs.core.pckg.enums.UserRequestIndexingStatus
 import io.klibs.core.pckg.repository.IndexingRequestRepository
+import io.klibs.core.pckg.repository.NonKmpPackageRepository
 import io.klibs.core.pckg.repository.PackageIndexRepository
 import io.klibs.core.pckg.repository.PackageRepository
 import io.klibs.core.pckg.repository.UserRequestIssueRepository
@@ -37,6 +38,8 @@ import org.apache.maven.model.Scm
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -59,6 +62,9 @@ class PackageIndexingServiceTest : BaseUnitWithDbLayerTest() {
 
     @Autowired
     private lateinit var packageRepository: PackageRepository
+
+    @Autowired
+    private lateinit var nonKmpPackageRepository: NonKmpPackageRepository
 
     @Autowired
     private lateinit var packageIndexRepository: PackageIndexRepository
@@ -193,6 +199,91 @@ class PackageIndexingServiceTest : BaseUnitWithDbLayerTest() {
         assertEquals(foundPackages.get(0).groupId, packageIndexRequestBeforeProcessing.groupId)
         assertEquals(foundPackages.get(0).artifactId, packageIndexRequestBeforeProcessing.artifactId)
         assertEquals(foundPackages.get(0).version, packageIndexRequestBeforeProcessing.version)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    @Sql(scripts = ["classpath:sql/PackageIndexingServiceTest/insert-request-for-processing.sql"])
+    fun `should classify request as non-KMP when pom exists but tooling metadata is missing`(hasMetadata: Boolean) {
+        if (!hasMetadata) jdbcTemplate.update("UPDATE package_index_request SET released_ts = NULL WHERE id = 1")
+        val indexRequest = indexingRequestRepository.findFirstForIndexing(indexingConfigurationProperties.retry.maxAttempts)
+        assertNotNull(indexRequest)
+
+        val releaseTs = Instant.parse("2026-09-01T12:00:00Z")
+        val scmUrl = if (hasMetadata) "https://gitlab.com/example/test-artifact" else null
+        val pom = mock<MavenPom>()
+        whenever(pom.groupId).thenReturn(indexRequest.groupId)
+        whenever(pom.artifactId).thenReturn(indexRequest.artifactId)
+        whenever(pom.version).thenReturn(indexRequest.version)
+        whenever(pom.scm).thenReturn(scmUrl?.let { Scm().apply { url = it } })
+        whenever(mavenStaticDataProvider.getPomWithReleaseDate(any()))
+            .thenReturn(PomWithReleaseDate(pom, releaseTs))
+        whenever(mavenStaticDataProvider.getKotlinToolingMetadata(any()))
+            .thenAnswer { null }
+
+        val beforeProcessing = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        val result = uut.processPackageQueue()
+
+        assertTrue(result, "Should return true when a request is classified")
+        assertFalse(indexingRequestRepository.existsById(indexRequest.idNotNull))
+        assertNull(
+            packageRepository.findByGroupIdAndArtifactIdAndVersion(
+                indexRequest.groupId,
+                indexRequest.artifactId,
+                requireNotNull(indexRequest.version),
+            ),
+            "Non-KMP artifacts must not create package rows",
+        )
+        val savedId = jdbcTemplate.queryForObject(
+            """
+                SELECT nkp.id
+                FROM non_kmp_packages nkp JOIN maven_artifact ma ON ma.id = nkp.maven_artifact_id
+                WHERE ma.group_id = ? AND ma.artifact_id = ? AND ma.version = ?
+            """.trimIndent(),
+            Long::class.java,
+            indexRequest.groupId, indexRequest.artifactId, requireNotNull(indexRequest.version),
+        )
+        val row = nonKmpPackageRepository.findById(requireNotNull(savedId)).orElseThrow()
+        assertEquals(indexRequest.releasedAt ?: releaseTs, row.releaseTs)
+        assertEquals(indexRequest.repo, row.repo)
+        assertEquals(scmUrl, row.scmUrl)
+        assertTrue(row.createdAt >= beforeProcessing && row.createdAt <= Instant.now())
+    }
+
+    @Test
+    @Sql(scripts = ["classpath:sql/PackageIndexingServiceTest/insert-failed-tooling-metadata-request.sql"])
+    fun `should make historical tooling metadata failures retryable after reset`() {
+        assertNull(
+            indexingRequestRepository.findFirstForIndexing(indexingConfigurationProperties.retry.maxAttempts),
+            "Historical tooling metadata failures should not be retryable before reset",
+        )
+
+        val updatedRows = jdbcTemplate.update(
+            """
+                UPDATE package_index_request
+                SET status = 'PENDING',
+                    failed_attempts = 0,
+                    failed_ts = NULL,
+                    last_error_message = NULL
+                WHERE last_error_message LIKE 'Unable to find tooling metadata for %'
+            """.trimIndent()
+        )
+
+        assertEquals(1, updatedRows)
+
+        val retryableRequest = indexingRequestRepository.findFirstForIndexing(indexingConfigurationProperties.retry.maxAttempts)
+        assertNotNull(retryableRequest)
+        assertEquals("com.example", retryableRequest.groupId)
+        assertEquals("stale-tooling-metadata", retryableRequest.artifactId)
+        assertEquals("1.0.0", retryableRequest.version)
+
+        val resetRow = jdbcTemplate.queryForMap(
+            "SELECT status, failed_attempts, failed_ts, last_error_message FROM package_index_request WHERE id = 9201"
+        )
+        assertEquals("PENDING", resetRow["status"])
+        assertEquals(0, (resetRow["failed_attempts"] as Number).toInt())
+        assertNull(resetRow["failed_ts"])
+        assertNull(resetRow["last_error_message"])
     }
 
     @Test

--- a/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTestOld.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTestOld.kt
@@ -7,6 +7,7 @@ import io.klibs.core.pckg.entity.IndexingRequestEntity
 import io.klibs.core.pckg.repository.IndexingRequestRepository
 import io.klibs.core.pckg.repository.PackageRepository
 import io.klibs.core.pckg.service.MavenArtifactService
+import io.klibs.core.pckg.service.NonKmpPackageService
 import io.klibs.core.pckg.service.PackageService
 import io.klibs.integration.ai.PackageDescriptionGenerator
 import io.klibs.integration.maven.MavenArtifact
@@ -43,6 +44,7 @@ class PackageIndexingServiceTestOld {
     private val packageService: PackageService = mock()
     private val packageRepository: PackageRepository = mock()
     private val mavenArtifactService: MavenArtifactService = mock()
+    private val nonKmpPackageService: NonKmpPackageService = mock()
     private val transactionTemplate: TransactionTemplate = mock()
     private val selfProvider: ObjectProvider<PackageIndexingService> = mock()
 
@@ -65,6 +67,7 @@ class PackageIndexingServiceTestOld {
             packageService,
             packageRepository,
             mavenArtifactService,
+            nonKmpPackageService,
             IndexingConfigurationProperties(),
             selfProvider
         )
@@ -94,7 +97,6 @@ class PackageIndexingServiceTestOld {
             releasedAt = artifact.releasedAt,
             repo = artifact.scraperType
         )))
-        whenever(indexingRequestRepository.removeRepeating()).thenReturn(0)
 
         service.indexNewPackages()
 
@@ -105,7 +107,6 @@ class PackageIndexingServiceTestOld {
                     list[0].version == artifact.version &&
                     list[0].repo == artifact.scraperType
         })
-        verify(indexingRequestRepository).removeRepeating()
     }
 
     private fun provider(scraperType: ScraperType): MavenStaticDataProvider =

--- a/app/src/test/kotlin/io/klibs/core/pckg/repository/PackageRepositoryTest.kt
+++ b/app/src/test/kotlin/io/klibs/core/pckg/repository/PackageRepositoryTest.kt
@@ -1,0 +1,26 @@
+package io.klibs.core.pckg.repository
+
+import BaseUnitWithDbLayerTest
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.jdbc.Sql
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@ActiveProfiles("test")
+class PackageRepositoryTest : BaseUnitWithDbLayerTest() {
+
+    @Autowired
+    private lateinit var packageRepository: PackageRepository
+
+    @Test
+    @Sql("classpath:sql/PackageRepositoryTest/insert-known-non-kmp-package.sql")
+    fun `should include non-KMP artifacts in known maven central packages`() {
+        val knownPackages = packageRepository.findAllKnownMavenCentralPackages()
+        val knownArtifact = knownPackages.find { it.groupId == "com.example" && it.artifactId == "non-kmp-artifact" }
+
+        assertNotNull(knownArtifact)
+        assertEquals(setOf("1.0.0"), knownArtifact.versions)
+    }
+}

--- a/app/src/test/resources/sql/PackageIndexingServiceTest/insert-failed-tooling-metadata-request.sql
+++ b/app/src/test/resources/sql/PackageIndexingServiceTest/insert-failed-tooling-metadata-request.sql
@@ -1,0 +1,26 @@
+INSERT INTO package_index_request(
+    id,
+    group_id,
+    artifact_id,
+    version,
+    released_ts,
+    scraper_type,
+    reindex,
+    failed_attempts,
+    failed_ts,
+    last_error_message,
+    status
+)
+VALUES (
+    9201,
+    'com.example',
+    'stale-tooling-metadata',
+    '1.0.0',
+    CURRENT_TIMESTAMP,
+    'CENTRAL_SONATYPE',
+    false,
+    999,
+    CURRENT_TIMESTAMP,
+    'Unable to find tooling metadata for com.example:stale-tooling-metadata:1.0.0(CENTRAL_SONATYPE)',
+    'FAILED'
+);

--- a/app/src/test/resources/sql/PackageRepositoryTest/insert-known-non-kmp-package.sql
+++ b/app/src/test/resources/sql/PackageRepositoryTest/insert-known-non-kmp-package.sql
@@ -1,0 +1,5 @@
+INSERT INTO public.maven_artifact (id, group_id, artifact_id, version)
+VALUES (9201, 'com.example', 'non-kmp-artifact', '1.0.0');
+
+INSERT INTO public.non_kmp_packages (id, maven_artifact_id, release_ts, scraper_type)
+VALUES (9201, 9201, '2026-09-04 00:00:00', 'CENTRAL_SONATYPE');

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/entity/NonKmpPackageEntity.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/entity/NonKmpPackageEntity.kt
@@ -1,0 +1,43 @@
+package io.klibs.core.pckg.entity
+
+import io.klibs.integration.maven.ScraperType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "non_kmp_packages")
+data class NonKmpPackageEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "non_kmp_packages_id_seq")
+    @SequenceGenerator(name = "non_kmp_packages_id_seq", sequenceName = "non_kmp_packages_id_seq")
+    @Column(name = "id")
+    val id: Long? = null,
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "maven_artifact_id", nullable = false)
+    val mavenArtifact: MavenArtifactEntity,
+
+    @Column(name = "release_ts", nullable = false)
+    val releaseTs: Instant,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "scraper_type", nullable = false)
+    val repo: ScraperType,
+
+    @Column(name = "scm_url")
+    val scmUrl: String?,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+)

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/repository/IndexingRequestRepository.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/repository/IndexingRequestRepository.kt
@@ -48,22 +48,6 @@ interface IndexingRequestRepository : CrudRepository<IndexingRequestEntity, Long
     """, nativeQuery = true)
     fun markAsFailed(@Param("id") id: Long, @Param("errorMessage") errorMessage: String?)
 
-    @Modifying
-    @Transactional
-    @Query(value = """
-        DELETE
-        FROM package_index_request req
-        WHERE req.reindex = false
-          AND EXISTS (
-              SELECT true
-              FROM package p
-              WHERE req.group_id = p.group_id
-                AND req.artifact_id = p.artifact_id
-                AND req.version = p.version
-          )
-    """, nativeQuery = true)
-    fun removeRepeating(): Int
-
     fun findByGroupIdAndArtifactIdAndVersion(
         groupId: String,
         artifactId: String,

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/repository/NonKmpPackageRepository.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/repository/NonKmpPackageRepository.kt
@@ -1,0 +1,6 @@
+package io.klibs.core.pckg.repository
+
+import io.klibs.core.pckg.entity.NonKmpPackageEntity
+import org.springframework.data.repository.CrudRepository
+
+interface NonKmpPackageRepository : CrudRepository<NonKmpPackageEntity, Long>

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/repository/PackageRepository.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/repository/PackageRepository.kt
@@ -20,8 +20,12 @@ interface PackageRepository: CrudRepository<PackageEntity, Long> {
                  SELECT group_id, artifact_id, version, scraper_type FROM package
                  UNION ALL
                  SELECT group_id, artifact_id, version, scraper_type FROM package_index_request
+                 UNION ALL
+                 SELECT ma.group_id, ma.artifact_id, ma.version, nkp.scraper_type AS scraper_type
+                 FROM non_kmp_packages nkp
+                 JOIN maven_artifact ma ON ma.id = nkp.maven_artifact_id
              ) AS combined
-        WHERE scraper_type != 'GOOGLE_MAVEN'
+        WHERE scraper_type IS DISTINCT FROM 'GOOGLE_MAVEN'
         GROUP BY combined.group_id, combined.artifact_id;
         """,
         nativeQuery = true)

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/service/NonKmpPackageService.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/service/NonKmpPackageService.kt
@@ -1,0 +1,25 @@
+package io.klibs.core.pckg.service
+
+import io.klibs.core.pckg.dto.MavenArtifactDTO
+import io.klibs.core.pckg.entity.NonKmpPackageEntity
+import io.klibs.core.pckg.repository.NonKmpPackageRepository
+import io.klibs.integration.maven.ScraperType
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class NonKmpPackageService(
+    private val nonKmpPackageRepository: NonKmpPackageRepository,
+) {
+
+    fun save(mavenArtifact: MavenArtifactDTO, releaseTs: Instant, repo: ScraperType, scmUrl: String?) {
+        nonKmpPackageRepository.save(
+            NonKmpPackageEntity(
+                mavenArtifact = mavenArtifact.toEntityRef(),
+                releaseTs = releaseTs,
+                repo = repo,
+                scmUrl = scmUrl,
+            )
+        )
+    }
+}

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/MavenStaticDataProvider.kt
@@ -6,9 +6,27 @@ import io.klibs.integration.maven.androidx.ModuleMetadataWrapper
 import io.klibs.integration.maven.delegate.KotlinToolingMetadataDelegate
 import io.klibs.integration.maven.dto.MavenMetadata
 import java.time.Instant
+import org.apache.maven.model.Dependency
+import org.apache.maven.model.License
 import org.apache.maven.model.Model
+import org.apache.maven.model.Scm
 
-typealias MavenPom = Model
+class MavenPom(private val model: Model) {
+
+    val groupId: String
+        get() = model.groupId ?: model.parent?.groupId ?: error("No groupId found for ${scm?.url}")
+
+    val version: String
+        get() = model.version ?: model.parent?.version ?: error("No version found for ${scm?.url}")
+
+    val artifactId: String get() = model.artifactId ?: error("No artifactId found for ${scm?.url}")
+    val description: String? get() = model.description
+    val url: String? get() = model.url
+    val scm: Scm? get() = model.scm
+    val developers get() = model.developers ?: emptyList()
+    val licenses: List<License> get() = model.licenses ?: emptyList()
+    val dependencies: List<Dependency> get() = model.dependencies ?: emptyList()
+}
 
 data class PomWithReleaseDate(val pom: MavenPom, val releasedAt: Instant)
 

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/AndoroidMavenStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/AndoroidMavenStaticDataProvider.kt
@@ -8,10 +8,6 @@ import io.klibs.integration.maven.androidx.GradleMetadata
 import io.klibs.integration.maven.delegate.KotlinToolingMetadataDelegate
 import io.klibs.integration.maven.delegate.KotlinToolingMetadataDelegateStubImpl
 import io.klibs.integration.maven.request.RequestRateLimiter
-import java.time.format.DateTimeFormatter
-import kotlin.time.Instant
-import java.time.ZonedDateTime
-import kotlin.time.toKotlinInstant
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -27,7 +23,6 @@ class GoogleMavenStaticDataProvider(
     rateLimiter = unlimitedRateLimiter,
     logger = logger,
     objectMapper = objectMapper,
-    lastModifiedHeader = "last-modified"
 ) {
     override fun getContentUrlPrefix(): String {
         return GOOGLE_MAVEN_URL
@@ -48,8 +43,6 @@ class GoogleMavenStaticDataProvider(
             getModuleMetadata(mavenArtifact.groupId, mavenArtifact.artifactId, mavenArtifact.version) ?: return null
         return convertModuleToToolingMetadata(moduleMetadata.gradleMetadata)
     }
-
-    override fun parseReleasedAt(value: String): Instant = parseRfc1123Instant(value)
 
     private fun convertModuleToToolingMetadata(metadata: GradleMetadata): KotlinToolingMetadataDelegate {
         return KotlinToolingMetadataDelegateStubImpl(metadata)

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenCentralStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenCentralStaticDataProvider.kt
@@ -14,7 +14,6 @@ abstract class BaseMavenCentralStaticDataProvider(
     logger: Logger,
     objectMapper: ObjectMapper,
     private val contentEndpoint: String,
-    lastModifiedHeader: String,
     clientTransport: Transport = Java11HttpClientTransport(),
     clock: Clock = Clock.System,
 ) : BaseMavenStaticDataProvider(
@@ -24,7 +23,6 @@ abstract class BaseMavenCentralStaticDataProvider(
     objectMapper = objectMapper,
     clientTransport = clientTransport,
     clock = clock,
-    lastModifiedHeader = lastModifiedHeader
 ) {
 
     override fun getContentUrlPrefix(): String = contentEndpoint

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenStaticDataProvider.kt
@@ -58,7 +58,7 @@ abstract class BaseMavenStaticDataProvider(
         return executeFetch(pomFileUrl) { response ->
             val pom =
                 mavenXpp3Reader.read(StringReader(response.body.readAllBytes().toString(StandardCharsets.UTF_8)))
-            PomWithReleaseDate(pom, getReleasedAt(response).toJavaInstant())
+            PomWithReleaseDate(MavenPom(pom), getReleasedAt(response).toJavaInstant())
         }
     }
 

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/BaseMavenStaticDataProvider.kt
@@ -44,7 +44,6 @@ abstract class BaseMavenStaticDataProvider(
     private val objectMapper: ObjectMapper,
     private val clientTransport: Transport = Java11HttpClientTransport(),
     private val clock: Clock = Clock.System,
-    private val lastModifiedHeader: String,
 ) : MavenStaticDataProvider {
 
     private val mavenXpp3Reader = MavenXpp3Reader()
@@ -141,7 +140,16 @@ abstract class BaseMavenStaticDataProvider(
         }
     }
 
-    protected abstract fun parseReleasedAt(value: String): Instant
+    protected open fun parseReleasedAt(value: Map<String, String>): Instant {
+        val lastModified = value.entries.firstOrNull { it.key.equals("last-modified", ignoreCase = true) }?.value
+            ?: throw IllegalStateException("Missing release date header: expected last-modified")
+
+        return try {
+            parseRfc1123Instant(lastModified)
+        } catch (e: Exception) {
+            throw IllegalStateException("Invalid release date format: $lastModified", e)
+        }
+    }
 
     protected fun <T> executeWithThrottle(body: () -> T): T {
         try {
@@ -155,14 +163,7 @@ abstract class BaseMavenStaticDataProvider(
     }
 
     protected fun getReleasedAt(response: Transport.Response): Instant {
-        val lastModified = response.getHeaderValue(lastModifiedHeader)
-            ?: throw IllegalStateException("Missing release date header: expected $lastModifiedHeader")
-
-        return try {
-            parseReleasedAt(lastModified)
-        } catch (e: Exception) {
-            throw IllegalStateException("Invalid release date format: $lastModified", e)
-        }
+        return parseReleasedAt(response.headers)
     }
 
     protected fun parseRfc1123Instant(value: String): Instant {
@@ -261,9 +262,6 @@ abstract class BaseMavenStaticDataProvider(
         return metadata
     }
 
-    private fun Transport.Response.getHeaderValue(headerName: String): String? {
-        return headers.entries.firstOrNull { it.key.equals(headerName, ignoreCase = true) }?.value
-    }
 
     private fun applyRequestCooldown(response: Transport.Response, serviceUri: String): Nothing {
         logger.warn("Rate limited by Maven Central, retrying after ${response.headers["Retry-After"]}")

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/GoogleMavenCentralMirrorStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/GoogleMavenCentralMirrorStaticDataProvider.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.request.impl.MavenCentralRateLimiter
 import kotlin.time.Clock
+import kotlin.time.Instant
 import org.apache.maven.search.api.transport.Java11HttpClientTransport
 import org.apache.maven.search.api.transport.Transport
 import org.slf4j.LoggerFactory
@@ -26,12 +27,27 @@ class GoogleMavenCentralMirrorStaticDataProvider(
     LoggerFactory.getLogger(GoogleMavenCentralMirrorStaticDataProvider::class.java),
     objectMapper,
     contentEndpoint,
-    "x-goog-meta-last-modified-epoch",
     clientTransport,
     clock
 ) {
     override val scraperType: ScraperType
         get() = ScraperType.GOOGLE_MAVEN_CENTRAL_MIRROR
 
-    override fun parseReleasedAt(value: String) = parseEpochMillisecondsInstant(value)
+    override fun parseReleasedAt(value: Map<String, String>): Instant {
+        val epoch = value.entries
+            .firstOrNull { it.key.equals("x-goog-meta-last-modified-epoch", ignoreCase = true) }
+            ?.value
+        val lastModified = epoch ?: value.entries
+            .firstOrNull { it.key.equals("x-goog-meta-mtime", ignoreCase = true) }
+            ?.value
+            ?: throw IllegalStateException(
+                "Missing release date header: expected x-goog-meta-last-modified-epoch or x-goog-meta-mtime"
+            )
+
+        return try {
+            if (epoch != null) parseEpochMillisecondsInstant(lastModified) else Instant.parse(lastModified)
+        } catch (e: Exception) {
+            throw IllegalStateException("Invalid release date format: $lastModified", e)
+        }
+    }
 }

--- a/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/SonatypeCentralStaticDataProvider.kt
+++ b/integrations/maven/src/main/kotlin/io/klibs/integration/maven/service/impl/SonatypeCentralStaticDataProvider.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.request.impl.MavenCentralRateLimiter
-import kotlin.time.Instant
 import kotlin.time.Clock
 import org.apache.maven.search.api.transport.Java11HttpClientTransport
 import org.apache.maven.search.api.transport.Transport
@@ -27,12 +26,9 @@ class SonatypeCentralStaticDataProvider(
     LoggerFactory.getLogger(SonatypeCentralStaticDataProvider::class.java),
     objectMapper,
     contentEndpoint,
-    "last-modified",
     clientTransport,
     clock
 ) {
     override val scraperType: ScraperType
         get() = ScraperType.CENTRAL_SONATYPE
-
-    override fun parseReleasedAt(value: String): Instant = parseRfc1123Instant(value)
 }

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/BaseMavenStaticDataProviderURLBuilderTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/BaseMavenStaticDataProviderURLBuilderTest.kt
@@ -16,10 +16,9 @@ class BaseMavenStaticDataProviderURLBuilderTest {
         logger = mock(),
         objectMapper = mock(),
         clientTransport = mock(),
-        lastModifiedHeader = "last-modified"
     ) {
         override fun getContentUrlPrefix(): String = "https://example.com/repo/"
-        override fun parseReleasedAt(value: String): Instant {
+        override fun parseReleasedAt(value: Map<String, String>): Instant {
             TODO("Not yet implemented")
         }
 

--- a/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/GoogleMavenCentralMirrorStaticDataProviderTest.kt
+++ b/integrations/maven/src/test/kotlin/io/klibs/integration/maven/search/impl/GoogleMavenCentralMirrorStaticDataProviderTest.kt
@@ -1,0 +1,127 @@
+package io.klibs.integration.maven.search.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.klibs.integration.maven.MavenArtifact
+import io.klibs.integration.maven.ScraperType
+import io.klibs.integration.maven.request.impl.MavenCentralRateLimiter
+import io.klibs.integration.maven.service.impl.GoogleMavenCentralMirrorStaticDataProvider
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.apache.maven.search.api.transport.Transport
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class GoogleMavenCentralMirrorStaticDataProviderTest {
+
+    @Test
+    fun `epoch header remains supported`() {
+        val releasedAt = fetchReleaseDate(mapOf("x-goog-meta-last-modified-epoch" to "1788177600000"))
+
+        assertEquals(Instant.parse("2026-08-31T12:00:00Z"), releasedAt)
+    }
+
+    @Test
+    fun `mtime is used when epoch header is absent`() {
+        val releasedAt = fetchReleaseDate(mapOf("x-goog-meta-mtime" to "2018-10-02T15:39:33.000000000Z"))
+
+        assertEquals(Instant.parse("2018-10-02T15:39:33Z"), releasedAt)
+    }
+
+    @Test
+    fun `epoch header takes precedence over mtime`() {
+        val releasedAt = fetchReleaseDate(
+            mapOf(
+                "x-goog-meta-last-modified-epoch" to "1788177600000",
+                "x-goog-meta-mtime" to "2018-10-02T15:39:33.000000000Z",
+            )
+        )
+
+        assertEquals(Instant.parse("2026-08-31T12:00:00Z"), releasedAt)
+    }
+
+    @Test
+    fun `release date headers are case insensitive`() {
+        assertEquals(
+            Instant.parse("2026-08-31T12:00:00Z"),
+            fetchReleaseDate(mapOf("X-Goog-Meta-Last-Modified-Epoch" to "1788177600000")),
+        )
+        assertEquals(
+            Instant.parse("2018-10-02T15:39:33.123456789Z"),
+            fetchReleaseDate(mapOf("X-Goog-Meta-Mtime" to "2018-10-02T15:39:33.123456789Z")),
+        )
+    }
+
+    @Test
+    fun `missing metadata headers fail even when Last-Modified is present`() {
+        for (headers in listOf(emptyMap(), mapOf("Last-Modified" to "Mon, 22 Jul 2019 22:43:40 GMT"))) {
+            val exception = assertFailsWith<IllegalStateException> { fetchReleaseDate(headers) }
+
+            assertTrue(exception.message.orEmpty().contains("Missing release date header"))
+        }
+    }
+
+    @Test
+    fun `invalid mtime fails as an invalid release date`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            fetchReleaseDate(mapOf("x-goog-meta-mtime" to "not-a-date"))
+        }
+
+        assertTrue(exception.message.orEmpty().contains("Invalid release date format"))
+        assertNotNull(exception.cause)
+    }
+
+    @Test
+    fun `invalid epoch does not silently fall back to mtime`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            fetchReleaseDate(
+                mapOf(
+                    "x-goog-meta-last-modified-epoch" to "not-an-epoch",
+                    "x-goog-meta-mtime" to "2018-10-02T15:39:33Z",
+                )
+            )
+        }
+
+        assertTrue(exception.message.orEmpty().contains("Invalid release date format"))
+        assertNotNull(exception.cause)
+    }
+
+    private fun fetchReleaseDate(headers: Map<String, String>): Instant {
+        val response = mock<Transport.Response>()
+        whenever(response.code).thenReturn(200)
+        whenever(response.headers).thenReturn(headers)
+        whenever(response.body).thenReturn(
+            """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kotlinx-coroutines-core</artifactId>
+                    <version>0.30.1</version>
+                </project>
+            """.trimIndent().byteInputStream()
+        )
+        val transport = mock<Transport>()
+        whenever(transport.get(any(), any())).thenReturn(response)
+        val rateLimiter = mock<MavenCentralRateLimiter>()
+        whenever(rateLimiter.withRateLimitBlocking(any<() -> Any?>())).thenAnswer { invocation ->
+            invocation.getArgument<() -> Any?>(0).invoke()
+        }
+        val uut = GoogleMavenCentralMirrorStaticDataProvider(
+            xmlMapper = XmlMapper(),
+            mavenCentralRateLimiter = rateLimiter,
+            objectMapper = ObjectMapper(),
+            contentEndpoint = "https://mirror.example/maven2/",
+            clientTransport = transport,
+        )
+        val artifact = MavenArtifact(
+            "org.jetbrains.kotlinx", "kotlinx-coroutines-core", "0.30.1", ScraperType.GOOGLE_MAVEN_CENTRAL_MIRROR
+        )
+        val (_, releasedAt) = assertNotNull(uut.getPomWithReleaseDate(artifact))
+        return releasedAt
+    }
+}


### PR DESCRIPTION
**TL;DR**
Added logic for classifying artifacts with an available POM but missing Kotlin tooling metadata as non-KMP instead of failing indexing and repeatedly retrying them.

---
**Changes**
• Persist non-KMP artifacts in a dedicated non_kmp_packages table linked to maven_artifact, without creating regular package entries.
• Extend the known-artifacts query to account for non-KMP artifacts.