### PR TITLE
ktl-4936 chore: add Air cloud startup script for frontend work

### DIFF
--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Air cloud environment startup for frontend work.
+#
+# Prepares the environment so an agent can:
+#   - run the Vitest component suite: cd frontend && npm run test:component
+#   - ask the UI Verify MCP server (see .mcp.json) what changed visually
+#
+# Deliberately out of scope:
+#   - Playwright browsers. The visual (*.visual.test.tsx) and e2e suites run in
+#     CI, so nothing here drives a real browser.
+#   - Screenshot baselines. UI Verify holds them server-side; the agent reads
+#     diffs over MCP instead of comparing locally.
+
+set -euo pipefail
+
+FRONTEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../frontend" && pwd)"
+cd "$FRONTEND_DIR"
+
+# Playwright arrives as a dev dependency of @vitest/browser-playwright and
+# @playwright/test. Keep its ~500MB browser download out of the image.
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
+# npm runs `prepare` (husky) on install, and husky expects a .git in the package
+# root. frontend/ is a subdirectory of the repo, and git hooks are useless to an
+# agent, so disable it rather than let install fail.
+export HUSKY=0
+
+# No lock-file hash bookkeeping: npm is already a no-op when node_modules
+# matches package-lock.json.
+echo "==> Installing frontend dependencies"
+npm install --no-audit --no-fund
+
+echo "==> Component test runner: vitest $(npx --no-install vitest --version)"
+
+if [[ -z "${UIVERIFY_API_KEY:-}" ]]; then
+    echo "==> WARNING: UIVERIFY_API_KEY is unset, so the 'uiverify' MCP server" >&2
+    echo "    in .mcp.json cannot authenticate. Set it to inspect visual diffs." >&2
+else
+    echo "==> UIVERIFY_API_KEY is set; the 'uiverify' MCP server can authenticate"
+fi
+
+echo "==> Frontend environment ready"

--- a/.air/cloud/startup.sh
+++ b/.air/cloud/startup.sh
@@ -2,6 +2,10 @@
 #
 # Air cloud environment startup for frontend work.
 #
+# Air runs this after cloning the repository and before the agent starts, on
+# every environment launch - including task resume - so every step here must be
+# idempotent.
+#
 # Prepares the environment so an agent can:
 #   - run the Vitest component suite: cd frontend && npm run test:component
 #   - ask the UI Verify MCP server (see .mcp.json) what changed visually
@@ -14,30 +18,46 @@
 
 set -euo pipefail
 
-FRONTEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../frontend" && pwd)"
-cd "$FRONTEND_DIR"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-# Playwright arrives as a dev dependency of @vitest/browser-playwright and
-# @playwright/test. Keep its ~500MB browser download out of the image.
-export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+# This script runs in its own process, so variables it exports never reach the
+# agent session; Air's mechanism for that is ~/.bashrc. Replace any earlier
+# definition rather than appending, which keeps resume from adding duplicates
+# and from leaving a stale value behind after a secret is rotated.
+persist_for_agent() {
+    local name="$1" value="$2" bashrc="$HOME/.bashrc" line
+    line="$(printf 'export %s=%q' "$name" "$value")"
+    touch "$bashrc"
+    if ! grep -qxF "$line" "$bashrc"; then
+        sed -i "/^export ${name}=/d" "$bashrc"
+        printf '%s\n' "$line" >>"$bashrc"
+    fi
+}
 
-# npm runs `prepare` (husky) on install, and husky expects a .git in the package
-# root. frontend/ is a subdirectory of the repo, and git hooks are useless to an
-# agent, so disable it rather than let install fail.
-export HUSKY=0
+# Done before the install below, so a failing install can't cost the agent its
+# UI Verify credentials.
+if [[ -n "${UIVERIFY_API_KEY:-}" ]]; then
+    # Never echo the value: this output lands in downloadable environment logs.
+    persist_for_agent UIVERIFY_API_KEY "$UIVERIFY_API_KEY"
+    echo "==> UIVERIFY_API_KEY exported for the agent; the 'uiverify' MCP server can authenticate"
+else
+    echo "==> WARNING: UIVERIFY_API_KEY is unset, so the 'uiverify' MCP server" >&2
+    echo "    in .mcp.json cannot authenticate. Add it to the environment secrets." >&2
+fi
+
+# Keep Playwright's ~500MB browser download out of the environment, and keep
+# husky from breaking npm install (it expects a .git in the package root, but
+# frontend/ is a subdirectory). The agent inherits both so that an npm install
+# it runs later behaves exactly like the one below.
+persist_for_agent PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD 1
+persist_for_agent HUSKY 0
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 HUSKY=0
 
 # No lock-file hash bookkeeping: npm is already a no-op when node_modules
 # matches package-lock.json.
 echo "==> Installing frontend dependencies"
+cd "$REPO_ROOT/frontend"
 npm install --no-audit --no-fund
 
 echo "==> Component test runner: vitest $(npx --no-install vitest --version)"
-
-if [[ -z "${UIVERIFY_API_KEY:-}" ]]; then
-    echo "==> WARNING: UIVERIFY_API_KEY is unset, so the 'uiverify' MCP server" >&2
-    echo "    in .mcp.json cannot authenticate. Set it to inspect visual diffs." >&2
-else
-    echo "==> UIVERIFY_API_KEY is set; the 'uiverify' MCP server can authenticate"
-fi
-
 echo "==> Frontend environment ready"


### PR DESCRIPTION
## Goal

Add `.air/cloud/startup.sh` so an Air cloud environment comes up ready for frontend changes.

| Capability | Status |
|---|---|
| Run component tests | ✅ `npm install` in `frontend/` so `npm run test:component` works |
| Run Playwright | ❌ browser download skipped via `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` |
| Call UI Verify over MCP | ✅ `UIVERIFY_API_KEY` persisted to `~/.bashrc` for the agent session |

## Passing variables to the agent

Per the [Air docs](https://www.jetbrains.com/help/air/configure-environments.html#cloud_startup_script), the startup script runs in a **separate process**, so variables it exports never reach the agent session — they have to be appended to `~/.bashrc`.

Three variables are persisted:

- `UIVERIFY_API_KEY` — so the `uiverify` MCP server in `.mcp.json` can authenticate.
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and `HUSKY=0` — so that an `npm install` the **agent** runs later (say, after adding a dependency) behaves like the one in this script, rather than pulling ~500MB of browsers or failing on husky.

Three details worth reviewing:

- **Replace rather than append.** The docs' `grep -q … || echo …` guard prevents duplicates on resume but keeps a stale value if a secret is rotated. `persist_for_agent` drops any earlier definition first, so it converges on the current value either way.
- **Persisted before `npm install`.** A failing install must not cost the agent its credentials.
- **The key is never echoed.** Startup output goes into downloadable environment logs.

## Idempotency

The docs note the script runs on **every** environment launch, including task resume and starting from a snapshot. Every step is guarded: `npm install` self-guards, and the `~/.bashrc` writes converge.

## Deliberate non-goals

- **No `package-lock.json` hash comparison.** `npm install` is already a no-op when `node_modules` matches the lock file. Verified: a second run finishes in ~1.4s with `up to date`.
- **No local screenshot baselines.** UI Verify holds them server-side; the agent reads diffs over MCP.
- **No Playwright browsers.** Visual (`*.visual.test.tsx`) and e2e suites run in CI (`ui-verify.yaml` does its own `playwright install`).

## Validation

Run against a clean environment (empty `node_modules`):

```
$ ./.air/cloud/startup.sh
==> UIVERIFY_API_KEY exported for the agent; the 'uiverify' MCP server can authenticate
==> Installing frontend dependencies
added 613 packages in 18s
==> Component test runner: vitest vitest/4.1.11 linux-x64 node-v25.2.1
==> Frontend environment ready

$ cd frontend && npm run test:component
Test Files  11 passed (11)
     Tests  23 passed (23)
```

Exercised against an isolated `HOME`:

| Case | Result |
|---|---|
| Fresh env, no `~/.bashrc` | File created with all three exports |
| Resume — 3 consecutive runs | Exactly 1 line per variable, no duplicates |
| Key rotation `AAA` → `BBB` | Value replaced in place, still 1 line |
| Pre-existing `~/.bashrc` content | Preserved |
| Key value containing `$ ' " \ ; ` + space | Round-trips byte-identical (`printf %q`) |
| `UIVERIFY_API_KEY` unset | Warns, still installs, writes no empty export |
| Secret in log output | Never printed |

Also confirmed: no `~/.cache/ms-playwright` is created, and `npm run test:visual` fails by design with Playwright's own `npx playwright install` hint — an escape hatch if someone needs it locally.

## Not included

The script does not create `frontend/.env.local`. None of the three capabilities need it (CI runs component tests without one), so it was left out to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)