### PR TITLE
KTL-2087: Integrated blacklist support into indexing process

### DIFF
--- a/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/PackageIndexingService.kt
@@ -15,6 +15,7 @@ import io.klibs.core.pckg.service.MavenArtifactService
 import io.klibs.core.pckg.service.NonKmpPackageService
 import io.klibs.core.pckg.service.PackageService
 import io.klibs.core.project.ProjectEntity
+import io.klibs.core.project.blacklist.BlacklistRepository
 import io.klibs.core.scm.repository.ScmRepositoryEntity
 import io.klibs.integration.ai.PackageDescriptionGenerator
 import io.klibs.integration.maven.MavenArtifact
@@ -53,6 +54,7 @@ class PackageIndexingService(
     private val userRequestReportWriter: UserRequestReportWriter,
     private val packageService: PackageService,
     private val packageRepository: PackageRepository,
+    private val blacklistRepository: BlacklistRepository,
     private val mavenArtifactService: MavenArtifactService,
     private val nonKmpPackageService: NonKmpPackageService,
     private val indexingConfigurationProperties: IndexingConfigurationProperties,
@@ -80,8 +82,11 @@ class PackageIndexingService(
                                 .buffer()  // Allows the flow to emit faster than a collection
                                 .chunked(size = 5)
                                 .collect { newArtifacts ->
-                                    if (newArtifacts.isNotEmpty()) {
-                                        val indexRequests = newArtifacts.map { it.toIndexRequest() }
+                                    val allowedArtifacts = newArtifacts.filterNot {
+                                        blacklistRepository.checkPackageBanned(it.groupId, it.artifactId)
+                                    }
+                                    if (allowedArtifacts.isNotEmpty()) {
+                                        val indexRequests = allowedArtifacts.map { it.toIndexRequest() }
                                         val insertedRequests = indexingRequestRepository.saveAll(indexRequests).count()
                                         logger.debug("Queued up $insertedRequests newArtifacts")
                                     }
@@ -115,8 +120,13 @@ class PackageIndexingService(
         var outcome = Outcome.FAILED
         var errorMessage: String? = null
         try {
-            selfProvider.getObject().processRequest(indexRequest)
-            outcome = Outcome.SUCCESS
+            if (blacklistRepository.checkPackageBanned(indexRequest.groupId, indexRequest.artifactId)) {
+                errorMessage = "Artifact ${indexRequest.groupId}:${indexRequest.artifactId} is banned"
+                outcome = Outcome.BANNED
+            } else {
+                selfProvider.getObject().processRequest(indexRequest)
+                outcome = Outcome.SUCCESS
+            }
         } catch (e: MavenRateLimitedException) {
             outcome = Outcome.RATE_LIMITED
             logger.warn("Stopping the indexing queue, request id=$requestId stays pending: ${e.message}")
@@ -126,6 +136,7 @@ class PackageIndexingService(
         } finally {
             try {
                 when (outcome) {
+                    Outcome.BANNED -> selfProvider.getObject().discardBannedRequest(requestId, errorMessage)
                     Outcome.SUCCESS -> {
                         userRequestReportWriter.saveSuccessReport(requestId)
                         indexingRequestRepository.deleteById(requestId)
@@ -146,7 +157,13 @@ class PackageIndexingService(
         return outcome != Outcome.RATE_LIMITED
     }
 
-    private enum class Outcome { SUCCESS, FAILED, RATE_LIMITED }
+    private enum class Outcome { SUCCESS, FAILED, RATE_LIMITED, BANNED }
+
+    @Transactional
+    internal fun discardBannedRequest(requestId: Long, errorMessage: String?) {
+        userRequestReportWriter.saveFailureReport(requestId, errorMessage)
+        indexingRequestRepository.deleteById(requestId)
+    }
 
     @Transactional
     internal fun processRequest(indexRequest: IndexingRequestEntity) {

--- a/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/BaseMavenCentralPackageDiscoverer.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/BaseMavenCentralPackageDiscoverer.kt
@@ -4,6 +4,7 @@ import io.klibs.app.indexing.discoverer.PackageDiscoverer
 import io.klibs.app.indexing.discoverer.collectAllKnownMavenCentralPackages
 import io.klibs.app.indexing.discoverer.createArtifactCoordinates
 import io.klibs.core.pckg.repository.PackageRepository
+import io.klibs.core.project.blacklist.BlacklistRepository
 import io.klibs.integration.maven.MavenArtifact
 import io.klibs.integration.maven.repository.MavenCentralLogRepository
 import io.klibs.integration.maven.service.MavenCentralScraper
@@ -16,6 +17,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.chunked
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onCompletion
@@ -28,6 +30,7 @@ abstract class BaseMavenCentralPackageDiscoverer(
     private val mavenCentralScraper: MavenCentralScraper,
     private val mavenCentralLogRepository: MavenCentralLogRepository,
     private val packageRepository: PackageRepository,
+    private val blacklistRepository: BlacklistRepository,
     private val fetchRemoteIndexTimestamp: () -> Instant?,
     private val sourceName: String,
 ) : PackageDiscoverer {
@@ -62,6 +65,7 @@ abstract class BaseMavenCentralPackageDiscoverer(
 
         return mavenIndexScannerService
             .scanForNewKMPArtifacts()
+            .filterNot { blacklistRepository.checkPackageBanned(it.groupId, it.artifactId) }
             .chunked(100)
             .flatMapConcat { foundArtifactsBatch ->
                 collectUnknownArtifacts(foundArtifactsBatch, existingPackages).asFlow()
@@ -77,6 +81,10 @@ abstract class BaseMavenCentralPackageDiscoverer(
 
     private suspend fun updateKnown(errorChannel: Channel<Exception>): Flow<MavenArtifact> {
         val existingPackages = collectAllKnownMavenCentralPackages(packageRepository)
+            .filterKeys { coordinates ->
+                val (groupId, artifactId) = coordinates.split(':', limit = 2)
+                !blacklistRepository.checkPackageBanned(groupId, artifactId)
+            }
 
         return mavenCentralScraper
             .findNewVersions(existingPackages, errorChannel)

--- a/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/CentralSonatypePackageDiscoverer.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/CentralSonatypePackageDiscoverer.kt
@@ -2,6 +2,7 @@ package io.klibs.app.indexing.discoverer.impl
 
 import io.klibs.app.configuration.properties.IndexingConfigurationProperties
 import io.klibs.core.pckg.repository.PackageRepository
+import io.klibs.core.project.blacklist.BlacklistRepository
 import io.klibs.integration.maven.repository.MavenCentralLogRepository
 import io.klibs.integration.maven.service.MavenCentralScraper
 import io.klibs.integration.maven.service.MavenIndexDownloadingService
@@ -20,12 +21,14 @@ class CentralSonatypePackageDiscoverer(
     mavenCentralLogRepository: MavenCentralLogRepository,
     packageRepository: PackageRepository,
     sonatypeCentralStaticDataProvider: BaseMavenCentralStaticDataProvider,
+    blacklistRepository: BlacklistRepository,
 ) : BaseMavenCentralPackageDiscoverer(
     mavenIndexDownloadingService = mavenIndexDownloadingService,
     mavenIndexScannerService = centralSonatypeMavenIndexScannerService,
     mavenCentralScraper = centralSonatypeScraper,
     mavenCentralLogRepository = mavenCentralLogRepository,
     packageRepository = packageRepository,
+    blacklistRepository = blacklistRepository,
     fetchRemoteIndexTimestamp = sonatypeCentralStaticDataProvider::fetchRemoteIndexTimestamp,
     sourceName = "Central sonatype",
 )

--- a/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/GoogleMavenCentralMirrorPackageDiscoverer.kt
+++ b/app/src/main/kotlin/io/klibs/app/indexing/discoverer/impl/GoogleMavenCentralMirrorPackageDiscoverer.kt
@@ -2,6 +2,7 @@ package io.klibs.app.indexing.discoverer.impl
 
 import io.klibs.app.configuration.properties.IndexingConfigurationProperties
 import io.klibs.core.pckg.repository.PackageRepository
+import io.klibs.core.project.blacklist.BlacklistRepository
 import io.klibs.integration.maven.repository.MavenCentralLogRepository
 import io.klibs.integration.maven.service.MavenCentralScraper
 import io.klibs.integration.maven.service.MavenIndexDownloadingService
@@ -20,12 +21,14 @@ class GoogleMavenCentralMirrorPackageDiscoverer(
     mavenCentralLogRepository: MavenCentralLogRepository,
     packageRepository: PackageRepository,
     googleMavenCentralMirrorStaticDataProvider: BaseMavenCentralStaticDataProvider,
+    blacklistRepository: BlacklistRepository,
 ) : BaseMavenCentralPackageDiscoverer(
     mavenIndexDownloadingService = mavenIndexDownloadingService,
     mavenIndexScannerService = googleMavenCentralMirrorIndexScannerService,
     mavenCentralScraper = googleMavenCentralMirrorScraper,
     mavenCentralLogRepository = mavenCentralLogRepository,
     packageRepository = packageRepository,
+    blacklistRepository = blacklistRepository,
     fetchRemoteIndexTimestamp = googleMavenCentralMirrorStaticDataProvider::fetchRemoteIndexTimestamp,
     sourceName = "Google Maven Central mirror",
 )

--- a/app/src/main/kotlin/io/klibs/app/service/UserRequestReportWriter.kt
+++ b/app/src/main/kotlin/io/klibs/app/service/UserRequestReportWriter.kt
@@ -15,4 +15,7 @@ interface UserRequestReportWriter {
      * No-op for requests not originating from a user issue.
      */
     fun saveFailureReportIfTerminal(indexRequestId: Long, errorMessage: String?)
+
+    /** Records an immediate FAILURE for a user-originated request, regardless of retries. */
+    fun saveFailureReport(indexRequestId: Long, errorMessage: String?)
 }

--- a/app/src/main/kotlin/io/klibs/app/service/impl/CentralSonatypeUserIndexingRequestService.kt
+++ b/app/src/main/kotlin/io/klibs/app/service/impl/CentralSonatypeUserIndexingRequestService.kt
@@ -58,6 +58,10 @@ class CentralSonatypeUserIndexingRequestService(
             return listOf(resolveSpecificVersion(groupId, artifactId, version))
         }
 
+        if (blacklistRepository.checkPackageBanned(groupId, artifactId)) {
+            throw UserRequestProcessingException("Artifact $groupId:$artifactId is banned")
+        }
+
         val foundPackages = searchForPackages(groupId, artifactId)
 
         val artifactsToSave = foundPackages

--- a/app/src/main/kotlin/io/klibs/app/service/impl/DatabaseUserRequestReportWriter.kt
+++ b/app/src/main/kotlin/io/klibs/app/service/impl/DatabaseUserRequestReportWriter.kt
@@ -39,8 +39,14 @@ class DatabaseUserRequestReportWriter(
     @Transactional
     override fun saveFailureReportIfTerminal(indexRequestId: Long, errorMessage: String?) {
         val indexRequest = indexingRequestRepository.findById(indexRequestId).orElse(null) ?: return
-        val issue = indexRequest.userRequestIssue ?: return
         if (indexRequest.failedAttempts < indexingConfigurationProperties.retry.maxAttempts) return
+        saveFailureReport(indexRequestId, errorMessage)
+    }
+
+    @Transactional
+    override fun saveFailureReport(indexRequestId: Long, errorMessage: String?) {
+        val indexRequest = indexingRequestRepository.findById(indexRequestId).orElse(null) ?: return
+        val issue = indexRequest.userRequestIssue ?: return
         val version = indexRequest.version ?: return
         userRequestReportRepository.save(
             UserRequestReportEntity(

--- a/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTest.kt
@@ -2,6 +2,7 @@ package io.klibs.app.indexing
 
 import BaseUnitWithDbLayerTest
 import io.klibs.app.configuration.properties.IndexingConfigurationProperties
+import io.klibs.app.indexing.discoverer.impl.CentralSonatypePackageDiscoverer
 import io.klibs.core.pckg.entity.IndexingRequestEntity
 import io.klibs.core.pckg.entity.UserRequestIssueEntity
 import io.klibs.core.pckg.enums.UserRequestIndexingStatus
@@ -18,6 +19,7 @@ import io.klibs.integration.github.GitHubIntegration
 import io.klibs.integration.github.model.GitHubRepository
 import io.klibs.integration.github.model.GitHubUser
 import io.klibs.integration.github.model.ReadmeFetchResult
+import io.klibs.integration.maven.MavenArtifact
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.androidx.GradleMetadata
 import io.klibs.integration.maven.androidx.Variant
@@ -34,6 +36,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.runBlocking
 import org.apache.maven.model.Scm
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -43,6 +47,8 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.system.CapturedOutput
@@ -95,6 +101,83 @@ class PackageIndexingServiceTest : BaseUnitWithDbLayerTest() {
 
     @MockitoBean
     private lateinit var readmeContentBuilder: ReadmeContentBuilder
+
+    @MockitoBean
+    private lateinit var discoverer: CentralSonatypePackageDiscoverer
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `scheduled discovery queues only allowed artifacts`(includeAllowed: Boolean) = runBlocking {
+        val artifacts = mutableListOf(
+            MavenArtifact("com.example", "lib", "1.0", ScraperType.CENTRAL_SONATYPE),
+            MavenArtifact("com.example", "lib", "2.0", ScraperType.CENTRAL_SONATYPE),
+            MavenArtifact("com.banned", "anything", "1.0", ScraperType.CENTRAL_SONATYPE),
+        )
+        if (includeAllowed) {
+            artifacts.add(MavenArtifact("com.example", "sibling", "1.0", ScraperType.CENTRAL_SONATYPE))
+        }
+        whenever(discoverer.discover(any())).thenReturn(artifacts.asFlow())
+
+        uut.indexNewPackages()
+
+        val requests = indexingRequestRepository.findAll().toList()
+        assertEquals(if (includeAllowed) 1 else 0, requests.size)
+        assertTrue(requests.all { it.groupId == "com.example" && it.artifactId == "sibling" })
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["com.example", "com.banned"])
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `discards banned scheduled requests without Maven access`(groupId: String) {
+        indexingRequestRepository.save(IndexingRequestEntity(
+            groupId = groupId, artifactId = "lib", version = "1.0.0",
+            releasedAt = Instant.now(), repo = ScraperType.CENTRAL_SONATYPE,
+        ))
+
+        assertTrue(uut.processPackageQueue())
+
+        assertEquals(0L, indexingRequestRepository.count())
+        assertEquals(0L, packageRepository.count())
+        assertEquals(0L, nonKmpPackageRepository.count())
+        assertEquals(0L, userRequestReportRepository.count())
+        verify(mavenStaticDataProvider, never()).getPomWithReleaseDate(any())
+        verify(mavenStaticDataProvider, never()).getKotlinToolingMetadata(any())
+        assertFalse(uut.processPackageQueue())
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1])
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `reports banned user request as failure and continues with allowed request`(failedAttempts: Int) {
+        val issue = saveUserOriginatedRequest(failedAttempts)
+        jdbcTemplate.update("UPDATE package_index_request SET artifact_id = 'lib'")
+
+        assertTrue(uut.processPackageQueue())
+
+        assertEquals(0L, indexingRequestRepository.count())
+        assertEquals(0L, packageRepository.count())
+        verify(mavenStaticDataProvider, never()).getPomWithReleaseDate(any())
+        verify(mavenStaticDataProvider, never()).getKotlinToolingMetadata(any())
+        val report = userRequestReportRepository.findAll().single()
+        assertEquals(UserRequestIndexingStatus.FAILURE, report.indexingStatus)
+        assertEquals("Artifact com.example:lib is banned", report.statusDetails)
+        assertEquals("1.0.0", report.version)
+        assertEquals(issue.id.toString(), jdbcTemplate.queryForObject(
+            "SELECT user_request_issue_id::text FROM user_request_report", String::class.java,
+        ))
+
+        indexingRequestRepository.save(IndexingRequestEntity(
+            groupId = "com.example", artifactId = "sibling", version = "1.0.0",
+            releasedAt = Instant.now(), repo = ScraperType.CENTRAL_SONATYPE,
+        ))
+        stubMavenFetch("com.example", "sibling", "1.0.0", null)
+        assertTrue(uut.processPackageQueue())
+        assertEquals(0L, indexingRequestRepository.count())
+        assertNotNull(packageRepository.findByGroupIdAndArtifactIdAndVersion("com.example", "sibling", "1.0.0"))
+        assertEquals(1L, userRequestReportRepository.count())
+        assertFalse(uut.processPackageQueue())
+    }
 
     @BeforeEach
     fun setUp() {

--- a/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTestOld.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/PackageIndexingServiceTestOld.kt
@@ -66,6 +66,7 @@ class PackageIndexingServiceTestOld {
             userRequestReportWriter,
             packageService,
             packageRepository,
+            mock(),
             mavenArtifactService,
             nonKmpPackageService,
             IndexingConfigurationProperties(),

--- a/app/src/test/kotlin/io/klibs/app/indexing/discoverer/impl/CentralSonatypePackageDiscovererTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/indexing/discoverer/impl/CentralSonatypePackageDiscovererTest.kt
@@ -2,6 +2,7 @@ package io.klibs.app.indexing.discoverer.impl
 
 import io.klibs.core.pckg.dto.projection.Package
 import io.klibs.core.pckg.repository.PackageRepository
+import io.klibs.core.project.blacklist.BlacklistRepository
 import io.klibs.integration.maven.MavenArtifact
 import io.klibs.integration.maven.ScraperType
 import io.klibs.integration.maven.repository.MavenCentralLogRepository
@@ -15,6 +16,8 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.times
@@ -47,6 +50,9 @@ internal class CentralSonatypePackageDiscovererTest {
     lateinit var packageRepository: PackageRepository
 
     @MockitoBean
+    lateinit var blacklistRepository: BlacklistRepository
+
+    @MockitoBean
     lateinit var centralSonatypeStaticDataProvider: SonatypeCentralStaticDataProvider
 
     lateinit var discoverer: CentralSonatypePackageDiscoverer
@@ -64,6 +70,56 @@ internal class CentralSonatypePackageDiscovererTest {
             mavenCentralLogRepository,
             packageRepository,
             centralSonatypeStaticDataProvider,
+            blacklistRepository,
+        )
+    }
+
+    private fun discovererFor(mirror: Boolean): BaseMavenCentralPackageDiscoverer = if (mirror) {
+        GoogleMavenCentralMirrorPackageDiscoverer(
+            mavenIndexDownloadingService,
+            mavenIndexScannerService,
+            centralSonatypeScraper,
+            mavenCentralLogRepository,
+            packageRepository,
+            centralSonatypeStaticDataProvider,
+            blacklistRepository,
+        )
+    } else discoverer
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun `should exclude banned packages from full discovery`(mirror: Boolean) = runTest {
+        whenever(packageRepository.findAllKnownMavenCentralPackages()).thenReturn(emptyList())
+        whenever(blacklistRepository.checkPackageBanned("com.example", "lib")).thenReturn(true)
+        whenever(blacklistRepository.checkPackageBanned("com.banned", "anything")).thenReturn(true)
+        whenever(mavenIndexDownloadingService.downloadIndexIfNewer(any(), any())).thenReturn(initialTimestamp)
+        val allowed = MavenArtifact("com.example", "sibling", "1.0", ScraperType.CENTRAL_SONATYPE)
+        whenever(mavenIndexScannerService.scanForNewKMPArtifacts()).thenReturn(flowOf(
+            MavenArtifact("com.example", "lib", "1.0", ScraperType.CENTRAL_SONATYPE),
+            MavenArtifact("com.banned", "anything", "1.0", ScraperType.CENTRAL_SONATYPE),
+            allowed,
+        ))
+
+        assertEquals(listOf(allowed), discovererFor(mirror).discover(Channel()).toList())
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun `should exclude banned coordinates before requesting new versions`(mirror: Boolean) = runTest {
+        whenever(packageRepository.findAllKnownMavenCentralPackages()).thenReturn(listOf(
+            Package("com.example", "lib", setOf("1.0")),
+            Package("com.banned", "anything", setOf("1.0")),
+            Package("com.example", "sibling", setOf("1.0")),
+        ))
+        whenever(blacklistRepository.checkPackageBanned("com.example", "lib")).thenReturn(true)
+        whenever(blacklistRepository.checkPackageBanned("com.banned", "anything")).thenReturn(true)
+        whenever(mavenIndexDownloadingService.downloadIndexIfNewer(any(), any())).thenReturn(null)
+        whenever(centralSonatypeScraper.findNewVersions(any(), any())).thenReturn(flowOf())
+
+        discovererFor(mirror).discover(Channel()).toList()
+
+        verify(centralSonatypeScraper).findNewVersions(
+            argThat { this == mapOf("com.example:sibling" to setOf("1.0")) }, any()
         )
     }
 

--- a/app/src/test/kotlin/io/klibs/app/service/impl/UserIndexingRequestServiceTest.kt
+++ b/app/src/test/kotlin/io/klibs/app/service/impl/UserIndexingRequestServiceTest.kt
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -211,25 +213,68 @@ class UserIndexingRequestServiceTest : BaseUnitWithDbLayerTest() {
         }
 
         assertEquals("Artifact com.example:lib:1.0.0 is banned", exception.reason)
+        assertNoMavenAccessOrQueuedRequests()
     }
 
     @Test
     @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
     fun `should throw 400 when all discovered artifacts are banned by group`() {
-        whenever(centralSonatypeSearchClient.getMavenMetadata(eq("com.banned"), eq("libX")))
-            .thenReturn(
-                MavenMetadata(
-                    "com.banned",
-                    "libX",
-                    MavenMetadata.Versioning(versions = listOf("1.0.0", "2.0.0"))
-                )
-            )
-        whenever(centralSonatypeSearchClient.getKotlinToolingMetadata(any())).thenReturn(mock<KotlinToolingMetadataDelegateStubImpl>())
         val exception = assertThrows<UserRequestProcessingException> {
             fulfillRequest(groupId = "com.banned", artifactId = "libX", version = null)
         }
 
-        assertEquals("All artifacts from this request are already indexed, queued or banned", exception.reason)
+        assertEquals("Artifact com.banned:libX is banned", exception.reason)
+        assertNoMavenAccessOrQueuedRequests()
+    }
+
+    @Test
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `should reject versionless exact ban before Maven access`() {
+        val exception = assertThrows<UserRequestProcessingException> {
+            fulfillRequest(version = null)
+        }
+
+        assertEquals("Artifact com.example:lib is banned", exception.reason)
+        assertNoMavenAccessOrQueuedRequests()
+    }
+
+    @Test
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `should reject specific version in banned group before Maven access`() {
+        val exception = assertThrows<UserRequestProcessingException> {
+            fulfillRequest(groupId = "com.banned", artifactId = "libX")
+        }
+
+        assertEquals("Artifact com.banned:libX:1.0.0 is banned", exception.reason)
+        assertNoMavenAccessOrQueuedRequests()
+    }
+
+    @Test
+    @Sql(value = ["classpath:/sql/UserIndexingRequestServiceTest/insert-into-banned-packages.sql"])
+    fun `should queue allowed sibling for specific and versionless requests`() {
+        whenever(centralSonatypeSearchClient.getMavenMetadata("com.example", "sibling"))
+            .thenReturn(
+                MavenMetadata(
+                    "com.example", "sibling",
+                    MavenMetadata.Versioning(versions = listOf("1.0.0", "2.0.0"))
+                )
+            )
+        whenever(centralSonatypeSearchClient.getKotlinToolingMetadata(any()))
+            .thenReturn(mock<KotlinToolingMetadataDelegateStubImpl>())
+
+        fulfillRequest(artifactId = "sibling")
+        fulfillRequest(artifactId = "sibling", version = null, githubIssueNumber = 43)
+
+        val requests = indexingRequestRepository.findAll().toList()
+        assertEquals(setOf("1.0.0", "2.0.0"), requests.map { it.version }.toSet())
+        assertEquals(2, requests.size)
+        assertTrue(requests.all { it.groupId == "com.example" && it.artifactId == "sibling" })
+    }
+
+    private fun assertNoMavenAccessOrQueuedRequests() {
+        assertEquals(0L, indexingRequestRepository.count())
+        verify(centralSonatypeSearchClient, never()).getMavenMetadata(any(), any())
+        verify(centralSonatypeSearchClient, never()).getKotlinToolingMetadata(any())
     }
 
     @Test

--- a/core/package/src/main/kotlin/io/klibs/core/pckg/repository/IndexingRequestRepository.kt
+++ b/core/package/src/main/kotlin/io/klibs/core/pckg/repository/IndexingRequestRepository.kt
@@ -25,12 +25,6 @@ interface IndexingRequestRepository : CrudRepository<IndexingRequestEntity, Long
         FROM package_index_request req
         WHERE req.status = 'PENDING'
           AND req.failed_attempts < :maxAttempts
-          AND NOT EXISTS (
-              SELECT 1
-              FROM banned_packages bp
-              WHERE bp.group_id = req.group_id 
-                AND (bp.artifact_id = req.artifact_id OR bp.artifact_id IS NULL)
-          )
         ORDER BY req.released_ts DESC NULLS FIRST
         LIMIT 1
     """, nativeQuery = true)


### PR DESCRIPTION
 Integrated blacklist support to exclude banned packages during indexing and discovery, updated services, and added comprehensive tests.